### PR TITLE
✨ [Feature] 공통 컴포넌트(폼) 구현

### DIFF
--- a/src/components/layout/ProductForm.module.css
+++ b/src/components/layout/ProductForm.module.css
@@ -1,0 +1,115 @@
+.formContainer {
+  display: flex;
+  flex-direction: column;
+  width: 316px;
+  gap: 20px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+}
+
+.label {
+  font-size: 14px;
+  font-weight: bold;
+  color: #5B6B6A;
+  margin-bottom: 4px;
+}
+
+.inputWrapper {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.textInput {
+  flex: 1;
+  border: none;
+  border-bottom: 2px solid #dddddd;
+  font-size: 14px;
+  font-weight: bold;
+  padding: 4px 0;
+  outline: none;
+}
+
+.priceWrapper {
+  display: flex;
+  gap: 4px;
+  margin: -8px 0 -4px 0;
+  align-items: baseline;
+}
+
+.priceInput {
+  width: 100%;
+  border: none;
+  font-size: 32px;
+  font-weight: bold;
+  outline: none;
+}
+
+.priceInput::placeholder,
+.textInput::placeholder {
+  color: #dddddd;
+  font-weight: bold;
+}
+
+.currency {
+  font-size: 32px;
+  font-weight: bold;
+}
+
+.message {
+  font-size: 12px;
+  margin-top: 0;
+}
+.errorMessage { color: #eb0000; }
+.successMessage { color: #008d02; }
+
+.chipGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip, .button {
+  display: flex;
+  height: 32px;
+  border: 1.5px solid #2F7F82;
+  border-radius: 16px;
+
+  color: #2F7F82;
+  background: white;
+  font-size: 14px;
+
+  padding: 0 12px;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+  cursor: pointer;
+}
+
+.button {
+  flex-shrink: 0;
+  border-radius: 5px;
+  color: white;
+  border-color: #243130;
+  background-color: #243130;
+}
+
+.chip:hover {
+  color: #2F7F82;
+  background-color: #E5F2F1;
+}
+
+.button:hover {
+  border-color: #5B6B6A;
+  background-color: #5B6B6A;
+}
+
+.chipSelected {
+  color: #fefefe;
+  background-color: #2F7F82;
+  font-weight: 500;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.25);
+}

--- a/src/components/layout/ProductForm.module.css
+++ b/src/components/layout/ProductForm.module.css
@@ -112,3 +112,15 @@
   font-weight: 500;
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.25);
 }
+
+.hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/layout/ProductForm.module.css
+++ b/src/components/layout/ProductForm.module.css
@@ -77,11 +77,9 @@
   height: 32px;
   border: 1.5px solid #2F7F82;
   border-radius: 16px;
-
   color: #2F7F82;
   background: white;
   font-size: 14px;
-
   padding: 0 12px;
   align-items: center;
   justify-content: center;
@@ -91,6 +89,7 @@
 
 .button {
   flex-shrink: 0;
+  width: 80px;
   border-radius: 5px;
   color: white;
   border-color: #243130;

--- a/src/components/layout/ProductForm.tsx
+++ b/src/components/layout/ProductForm.tsx
@@ -3,7 +3,7 @@ import styles from './ProductForm.module.css';
 import { CATEGORIES, TIME_OPTIONS } from '@/constants/product';
 
 export interface FormData {
-  link: string;
+  link?: string;
   price: number;
   name: string;
   category: string;
@@ -29,7 +29,7 @@ export function ProductForm({ formId = 'product-form', showTimeSelector = true, 
   }>({ loading: false, error: false, success: false });
 
   const handleLinkFetch = async () => {
-    if (!data.link.trim()) return;
+    if (!data.link?.trim()) return;
     setLinkStatus({ loading: true, error: false, success: false });
     
     try {
@@ -69,9 +69,10 @@ export function ProductForm({ formId = 'product-form', showTimeSelector = true, 
     <form id={formId} className={styles.formContainer} onSubmit={handleSubmit}>
       
       <div className={styles.field}>
-        <label className={styles.label}>상품 링크 (선택)</label>
+        <label htmlFor="link" className={styles.label}>상품 링크 (선택)</label>
         <div className={styles.inputWrapper}>
           <input
+            id="link"
             className={styles.textInput}
             placeholder="https://..."
             value={data.link}
@@ -85,7 +86,7 @@ export function ProductForm({ formId = 'product-form', showTimeSelector = true, 
           <button
             type="button"
             className={styles.button}
-            disabled={linkStatus.loading || !data.link.trim()}
+            disabled={linkStatus.loading || !data.link?.trim()}
             onClick={handleLinkFetch}
             >
               {linkStatus.loading ? '• • •' : '불러오기'}
@@ -100,9 +101,10 @@ export function ProductForm({ formId = 'product-form', showTimeSelector = true, 
       </div>
 
       <div className={styles.field}>
-        <label className={styles.label}>상품 가격</label>
+        <label htmlFor="price" className={styles.label}>상품 가격</label>
         <div className={styles.priceWrapper}>
           <input 
+            id="price"
             className={styles.priceInput} 
             type="text" 
             inputMode="numeric"
@@ -120,8 +122,9 @@ export function ProductForm({ formId = 'product-form', showTimeSelector = true, 
       </div>
 
       <div className={styles.field}>
-        <label className={styles.label}>상품명</label>
+        <label htmlFor="name" className={styles.label}>상품명</label>
         <input
+          id="name"
           className={styles.textInput}
           placeholder="직접 입력하거나 수정할 수 있어요"
           value={data.name}
@@ -164,8 +167,9 @@ export function ProductForm({ formId = 'product-form', showTimeSelector = true, 
       )}
 
       <div className={styles.field}>
-        <label className={styles.label}>사고 싶은 이유 (선택)</label>
+        <label htmlFor="reason" className={styles.label}>사고 싶은 이유 (선택)</label>
         <input
+          id="reason"
           className={styles.textInput}
           placeholder="스트레스 받아서? 진짜 필요해서?"
           value={data.reason}

--- a/src/components/layout/ProductForm.tsx
+++ b/src/components/layout/ProductForm.tsx
@@ -21,14 +21,50 @@ export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
     link: '', price: 0, name: '', category: '패션', time: '1일', reason: ''
   });
 
+  // const [linkStatus, setLinkStatus] = useState<{
+  //   loading: boolean;
+  //   error: boolean;
+  // }>({ loading: false, error: false });
+
+  // const handleLinkFetch = async () => {
+  //   if (!data.link.trim()) return;
+  //   setLinkStatus({ loading: true, error: false });
+    
+  //   try {
+  //     const result = await ~~~(data.link);  // API 호출부
+  //     setData(prev => ({
+  //       ...prev,
+  //       name: result.name,
+  //       price: result.price,
+  //     }));
+  //     setLinkStatus({ loading: false, error: false });
+  //   } catch (err) {
+  //     setLinkStatus({ loading: false, error: true });
+  //   }
+  // };
+    
   const [touched, setTouched] = useState({ price: false, name: false });
   const handleBlur = (field: 'price' | 'name') => setTouched({ ...touched, [field]: true });
   
   const priceError = touched.price && data.price === 0;
   const nameError = touched.name && data.name.trim() === '';
 
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    const isPriceEmpty = data.price === 0;
+    const isNameEmpty = data.name.trim() === '';
+
+    if (isPriceEmpty || isNameEmpty) {
+      setTouched({ price: true, name: true });
+      return;
+    }
+    
+    onSubmit(data);
+  };
+
   return (
-    <form className={styles.formContainer} onSubmit={(e) => { e.preventDefault(); onSubmit(data); }}>
+    <form className={styles.formContainer} onSubmit={handleSubmit}>
       
       <div className={styles.field}>
         <label className={styles.label}>상품 링크 (선택)</label>
@@ -36,10 +72,22 @@ export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
           <input
             className={styles.textInput}
             placeholder="https://..."
-            onChange={(e) => setData({...data, link: e.target.value})} />
-          <button type="button" className={styles.button}>불러오기</button>
+            value={data.link}
+            onChange={(e) => {
+              setData({...data, link: e.target.value});
+              // if (linkStatus.error) setLinkStatus({ loading: false, error: false});
+            }} />
+          <button
+            type="button"
+            className={styles.button}
+            // disabled={linkStatus.loading || !data.link.trim()}
+            // onClick={handleLinkFetch}
+            // {linkStatus.loading ? '• • •' : '불러오기'}
+            >불러오기</button>
         </div>
-        <p className={`${styles.message} ${styles.errorMessage}`}>URL을 불러오는 데 실패했습니다.</p>
+        {/* {linkStatus.error && ( */}
+          <p className={`${styles.message} ${styles.errorMessage}`}>URL을 불러오는 데 실패했습니다.</p>
+        {/* )} */}
       </div>
 
       <div className={styles.field}>
@@ -67,6 +115,7 @@ export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
         <input
           className={styles.textInput}
           placeholder="직접 입력하거나 수정할 수 있어요"
+          value={data.name}
           onBlur={() => handleBlur('name')}
           onChange={(e) => setData({...data, name: e.target.value})} />
         {nameError && <p className={`${styles.message} ${styles.errorMessage}`}>상품명은 필수 입력 사항입니다.</p>}
@@ -99,6 +148,7 @@ export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
         <input
           className={styles.textInput}
           placeholder="스트레스 받아서? 진짜 필요해서?"
+          value={data.reason}
           onChange={(e) => setData({...data, reason: e.target.value})} />
       </div>
     </form>

--- a/src/components/layout/ProductForm.tsx
+++ b/src/components/layout/ProductForm.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import styles from './ProductForm.module.css';
+import { CATEGORIES, TIME_OPTIONS } from '@/constants/product';
+
+export interface FormData {
+  link: string;
+  price: number;
+  name: string;
+  category: string;
+  time: string;
+  reason: string;
+}
+
+interface FormProps {
+  showTimeSelector?: boolean;
+  onSubmit: (data: FormData) => void;
+}
+
+export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
+  const [data, setData] = useState<FormData>({
+    link: '', price: 0, name: '', category: '패션', time: '1일', reason: ''
+  });
+
+  const [touched, setTouched] = useState({ price: false, name: false });
+  const handleBlur = (field: 'price' | 'name') => setTouched({ ...touched, [field]: true });
+  
+  const priceError = touched.price && data.price === 0;
+  const nameError = touched.name && data.name.trim() === '';
+
+  return (
+    <form className={styles.formContainer} onSubmit={(e) => { e.preventDefault(); onSubmit(data); }}>
+      
+      <div className={styles.field}>
+        <label className={styles.label}>상품 링크 (선택)</label>
+        <div className={styles.inputWrapper}>
+          <input
+            className={styles.textInput}
+            placeholder="https://..."
+            onChange={(e) => setData({...data, link: e.target.value})} />
+          <button type="button" className={styles.button}>불러오기</button>
+        </div>
+        <p className={`${styles.message} ${styles.errorMessage}`}>URL을 불러오는 데 실패했습니다.</p>
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label}>상품 가격</label>
+        <div className={styles.priceWrapper}>
+          <input 
+            className={styles.priceInput} 
+            type="text" 
+            inputMode="numeric"
+            placeholder="0"
+            value={data.price === 0 ? '' : data.price.toLocaleString('ko-KR')}
+            onBlur={() => handleBlur('price')}
+            onChange={(e) => {
+                const rawValue = e.target.value.replace(/[^0-9]/g, '');
+                setData({...data, price: rawValue === '' ? 0 : Number(rawValue)});
+            }} 
+          />
+          <span className={styles.currency}>원</span>
+        </div>
+        {priceError && <p className={`${styles.message} ${styles.errorMessage}`}>상품 가격은 필수 입력 사항입니다.</p>}
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label}>상품명</label>
+        <input
+          className={styles.textInput}
+          placeholder="직접 입력하거나 수정할 수 있어요"
+          onBlur={() => handleBlur('name')}
+          onChange={(e) => setData({...data, name: e.target.value})} />
+        {nameError && <p className={`${styles.message} ${styles.errorMessage}`}>상품명은 필수 입력 사항입니다.</p>}
+      </div>
+
+      <div className={styles.field}>
+        <label className={styles.label}>카테고리</label>
+        <div className={styles.chipGroup}>
+          {CATEGORIES.map(c => (
+            <div key={c} className={`${styles.chip} ${data.category === c ? styles.chipSelected : ''}`} 
+                 onClick={() => setData({...data, category: c})}>{c}</div>
+          ))}
+        </div>
+      </div>
+
+      {showTimeSelector && (
+        <div className={styles.field}>
+          <label className={styles.label}>고민해볼 시간</label>
+          <div className={styles.chipGroup}>
+            {TIME_OPTIONS.map(t => (
+              <div key={t} className={`${styles.chip} ${data.time === t ? styles.chipSelected : ''}`} 
+                   onClick={() => setData({...data, time: t})}>{t}</div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className={styles.field}>
+        <label className={styles.label}>사고 싶은 이유 (선택)</label>
+        <input
+          className={styles.textInput}
+          placeholder="스트레스 받아서? 진짜 필요해서?"
+          onChange={(e) => setData({...data, reason: e.target.value})} />
+      </div>
+    </form>
+  );
+}

--- a/src/components/layout/ProductForm.tsx
+++ b/src/components/layout/ProductForm.tsx
@@ -12,36 +12,38 @@ export interface FormData {
 }
 
 interface FormProps {
+  formId?: string;
   showTimeSelector?: boolean;
   onSubmit: (data: FormData) => void;
 }
 
-export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
+export function ProductForm({ formId = 'product-form', showTimeSelector = true, onSubmit }: FormProps) {
   const [data, setData] = useState<FormData>({
     link: '', price: 0, name: '', category: '패션', time: '1일', reason: ''
   });
 
-  // const [linkStatus, setLinkStatus] = useState<{
-  //   loading: boolean;
-  //   error: boolean;
-  // }>({ loading: false, error: false });
+  const [linkStatus, setLinkStatus] = useState<{
+    loading: boolean;
+    error: boolean;
+    success?: boolean;
+  }>({ loading: false, error: false, success: false });
 
-  // const handleLinkFetch = async () => {
-  //   if (!data.link.trim()) return;
-  //   setLinkStatus({ loading: true, error: false });
+  const handleLinkFetch = async () => {
+    if (!data.link.trim()) return;
+    setLinkStatus({ loading: true, error: false, success: false });
     
-  //   try {
-  //     const result = await ~~~(data.link);  // API 호출부
-  //     setData(prev => ({
-  //       ...prev,
-  //       name: result.name,
-  //       price: result.price,
-  //     }));
-  //     setLinkStatus({ loading: false, error: false });
-  //   } catch (err) {
-  //     setLinkStatus({ loading: false, error: true });
-  //   }
-  // };
+    try {
+      const result = await fetchProductData(data.link);  // API 호출부
+      setData(prev => ({
+        ...prev,
+        name: result.name,
+        price: result.price,
+      }));
+      setLinkStatus({ loading: false, error: false, success: true });
+    } catch {
+      setLinkStatus({ loading: false, error: true, success: false });
+    }
+  };
     
   const [touched, setTouched] = useState({ price: false, name: false });
   const handleBlur = (field: 'price' | 'name') => setTouched({ ...touched, [field]: true });
@@ -64,7 +66,7 @@ export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
   };
 
   return (
-    <form className={styles.formContainer} onSubmit={handleSubmit}>
+    <form id={formId} className={styles.formContainer} onSubmit={handleSubmit}>
       
       <div className={styles.field}>
         <label className={styles.label}>상품 링크 (선택)</label>
@@ -75,19 +77,26 @@ export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
             value={data.link}
             onChange={(e) => {
               setData({...data, link: e.target.value});
-              // if (linkStatus.error) setLinkStatus({ loading: false, error: false});
+              if (linkStatus.error || linkStatus.success) {
+                setLinkStatus({ loading: false, error: false, success: false });
+              }
+              
             }} />
           <button
             type="button"
             className={styles.button}
-            // disabled={linkStatus.loading || !data.link.trim()}
-            // onClick={handleLinkFetch}
-            // {linkStatus.loading ? '• • •' : '불러오기'}
-            >불러오기</button>
+            disabled={linkStatus.loading || !data.link.trim()}
+            onClick={handleLinkFetch}
+            >
+              {linkStatus.loading ? '• • •' : '불러오기'}
+            </button>
         </div>
-        {/* {linkStatus.error && ( */}
+        {linkStatus.error && (
           <p className={`${styles.message} ${styles.errorMessage}`}>URL을 불러오는 데 실패했습니다.</p>
-        {/* )} */}
+        )}
+        {linkStatus.success && (
+          <p className={`${styles.message} ${styles.successMessage}`}>URL을 성공적으로 불러왔습니다.</p>
+        )}
       </div>
 
       <div className={styles.field}>
@@ -123,10 +132,15 @@ export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
 
       <div className={styles.field}>
         <label className={styles.label}>카테고리</label>
-        <div className={styles.chipGroup}>
+        <div className={styles.chipGroup} role="radiogroup">
           {CATEGORIES.map(c => (
-            <div key={c} className={`${styles.chip} ${data.category === c ? styles.chipSelected : ''}`} 
-                 onClick={() => setData({...data, category: c})}>{c}</div>
+            <label key={c} className={`${styles.chip} ${data.category === c ? styles.chipSelected : ''}`}>
+              <input
+                type="radio" name="category" value={c} className={styles.hidden}
+                checked={data.category === c} onChange={() => setData({...data, category: c})}
+              />
+              {c}
+            </label>
           ))}
         </div>
       </div>
@@ -134,10 +148,16 @@ export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
       {showTimeSelector && (
         <div className={styles.field}>
           <label className={styles.label}>고민해볼 시간</label>
-          <div className={styles.chipGroup}>
+          <div className={styles.chipGroup} role="radiogroup">
             {TIME_OPTIONS.map(t => (
-              <div key={t} className={`${styles.chip} ${data.time === t ? styles.chipSelected : ''}`} 
-                   onClick={() => setData({...data, time: t})}>{t}</div>
+              <label key={t} className={`${styles.chip} ${data.time === t ? styles.chipSelected : ''}`}> 
+                <input
+                  type="radio" name="time" value={t} className={styles.hidden}
+                  checked={data.time === t}
+                  onChange={() => setData({...data, time: t})}
+                />   
+                {t}
+              </label>
             ))}
           </div>
         </div>
@@ -153,4 +173,10 @@ export function ProductForm({ showTimeSelector = true, onSubmit }: FormProps) {
       </div>
     </form>
   );
+}
+
+// 임시 코드: 실제 API 호출 로직 구현 필요
+async function fetchProductData(link: string): Promise<{ name: string; price: number }> {
+  console.log('fetchProductData called with link:', link);
+  throw new Error('Not implemented');
 }

--- a/src/constants/product.ts
+++ b/src/constants/product.ts
@@ -1,0 +1,6 @@
+export const CATEGORIES = [
+  '패션', '뷰티', '음식', '카페/디저트', '취미/굿즈', 
+  '전자기기', '건강/운동', '여행', '기타'
+] as const;
+
+export const TIME_OPTIONS = ['1시간', '1일', '3일', '7일'] as const;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,22 +1,11 @@
 import Header from '@/components/layout/Header'
-import { ProductForm, type FormData } from '@/components/layout/ProductForm'
 import Home from '@/features/home'
 
 export default function HomePage() {
-  const handleSubmit = (data: FormData) => {
-    console.log('제출된 데이터:', data);
-  };
-
   return (
     <>
       <Header />
       <Home />
-      <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px' }}>
-        <ProductForm
-          showTimeSelector={true} 
-          onSubmit={handleSubmit} 
-        />
-      </div>
     </>
   )
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,11 +1,22 @@
 import Header from '@/components/layout/Header'
+import { ProductForm, type FormData } from '@/components/layout/ProductForm'
 import Home from '@/features/home'
 
 export default function HomePage() {
+  const handleSubmit = (data: FormData) => {
+    console.log('제출된 데이터:', data);
+  };
+
   return (
     <>
       <Header />
       <Home />
+      <div style={{ display: 'flex', justifyContent: 'center', marginTop: '20px' }}>
+        <ProductForm
+          showTimeSelector={true} 
+          onSubmit={handleSubmit} 
+        />
+      </div>
     </>
   )
 }


### PR DESCRIPTION
## 📌 작업 내용

- 공통 컴포넌트 폼 구현 (소비기록, 유혹관리에 사용)
- 6개 항목(상품 링크, 상품 가격, 상품명, 카테고리, 고민해볼 시간, 사고 싶은 이유) 구성
- 공통 사용되는 상수값(카테고리 목록, 대기 시간 선택지) 분리

## 📷 스크린 샷

- 기본 구조
<img width="800" height="1200" alt="image" src="https://github.com/user-attachments/assets/0ea0e04b-27e7-4cb2-b5d5-54287b7e391c" />

- 내용 입력 시
<img width="800" height="1200" alt="image" src="https://github.com/user-attachments/assets/dad79311-ce97-408b-a699-85a88dc6fa70" />

- 필수 입력 사항 누락 시
<img width="800" height="1200" alt="image" src="https://github.com/user-attachments/assets/6fd78609-29cc-45be-b734-acf1c4e129c7" />

- 토큰 및 버튼 호버 기능 구현
<img width="596" height="150" alt="image" src="https://github.com/user-attachments/assets/344c5cb1-696b-4fc5-8847-fec27128fd6a" />
<img width="600" height="278" alt="image" src="https://github.com/user-attachments/assets/59938ccb-fc38-4e84-9907-c5db5bf31872" />

## ⚠️ 참고 사항

- 피그마 와이어프레임에 작성된 소비 기록 폼과 유혹 관리 폼의 UI를 적절하게 섞어 제작했습니다. (사소한 부분에서 차이가 있었음)
- 소비 기록의 경우 '고민해볼 시간' 항목이 제외되므로, 관련된 함수를 추가 작성했습니다.
- 버튼에 커서를 올릴 시 색상이 바뀌는 호버 코드를 추가적으로 작성했습니다.
- 분리한 상수값은 src/constants/product.ts 에 작성되어 있습니다.

## 🔗 관련 이슈

Closes #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 링크 입력으로 상품명/가격을 자동 불러오고, 카테고리·기간·사유를 한 번에 입력한 뒤 제출할 수 있는 상품 입력 폼을 추가했습니다.
  * 카테고리와 기간은 칩 UI로 선택하며, 필요 시 기간 선택 영역을 숨길 수 있습니다.
  * 한국어 금액 표기 및 입력/오류/성공 상태에 맞춘 전용 스타일을 적용했습니다.
* **버그 수정**
  * 상품명/가격 필수 검증과 에러 노출 타이밍을 개선하고, 가격 입력 형식을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->