### PR TITLE
✨ [Feature] 소비 기록 메인 화면 UI 구현

### DIFF
--- a/src/assets/legend-bg.svg
+++ b/src/assets/legend-bg.svg
@@ -1,0 +1,3 @@
+<svg width="244" height="73" viewBox="0 0 244 73" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 14.9787C0 6.70618 6.70619 0 14.9787 0H210.583L244 72.8855H14.9787C6.7062 72.8855 0 66.1793 0 57.9068V14.9787Z" fill="#E5F2F1"/>
+</svg>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,14 +1,11 @@
 .header {
   width: 100%;
   height: 50px;
-
   display: grid;
   grid-template-columns: 32px 1fr 32px;
   align-items: center;
-
   padding: 0 16px;
   box-sizing: border-box;
-
   background: var(--color-main-000, #f7fbfa);
 }
 
@@ -29,12 +26,9 @@
 
 .title {
   margin: 0;
-
   text-align: center;
-
   font-size: 18px;
   font-weight: 600;
   line-height: 1;
-
   color: #000;
 }

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,40 +1,40 @@
 .header {
-    width: 100%;
-    height: 50px;
-  
-    display: grid;
-    grid-template-columns: 32px 1fr 32px;
-    align-items: center;
-  
-    padding: 0 16px;
-    box-sizing: border-box;
-  
-    background: var(--color-main-000, #F7FBFA);
-  }
-  
-  .left,
-  .right {
-    display: flex;
-    align-items: center;
-    height: 100%;
-  }
-  
-  .left {
-    justify-content: flex-start;
-  }
-  
-  .right {
-    justify-content: flex-end;
-  }
-  
-  .title {
-    margin: 0;
-  
-    text-align: center;
-  
-    font-size: 18px;
-    font-weight: 600;
-    line-height: 1;
-  
-    color: #000;
-  }
+  width: 100%;
+  height: 50px;
+
+  display: grid;
+  grid-template-columns: 32px 1fr 32px;
+  align-items: center;
+
+  padding: 0 16px;
+  box-sizing: border-box;
+
+  background: var(--color-main-000, #f7fbfa);
+}
+
+.left,
+.right {
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
+
+.left {
+  justify-content: flex-start;
+}
+
+.right {
+  justify-content: flex-end;
+}
+
+.title {
+  margin: 0;
+
+  text-align: center;
+
+  font-size: 18px;
+  font-weight: 600;
+  line-height: 1;
+
+  color: #000;
+}

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -9,7 +9,7 @@
     padding: 0 16px;
     box-sizing: border-box;
   
-    background: var(--Main-000, #F7FBFA);
+    background: var(--color-main-000, #F7FBFA);
   }
   
   .left,

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -1,0 +1,40 @@
+.header {
+    width: 100%;
+    height: 50px;
+  
+    display: grid;
+    grid-template-columns: 32px 1fr 32px;
+    align-items: center;
+  
+    padding: 0 16px;
+    box-sizing: border-box;
+  
+    background: var(--Main-000, #F7FBFA);
+  }
+  
+  .left,
+  .right {
+    display: flex;
+    align-items: center;
+    height: 100%;
+  }
+  
+  .left {
+    justify-content: flex-start;
+  }
+  
+  .right {
+    justify-content: flex-end;
+  }
+  
+  .title {
+    margin: 0;
+  
+    text-align: center;
+  
+    font-size: 18px;
+    font-weight: 600;
+    line-height: 1;
+  
+    color: #000;
+  }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,0 +1,29 @@
+import styles from "./Header.module.css";
+
+interface HeaderProps {
+  title: string;
+  left?: React.ReactNode;
+  right?: React.ReactNode;
+}
+
+export default function Header({
+  title,
+  left,
+  right,
+}: HeaderProps) {
+  return (
+    <header className={styles.header}>
+      <div className={styles.left}>
+        {left}
+      </div>
+
+      <h1 className={styles.title}>
+        {title}
+      </h1>
+
+      <div className={styles.right}>
+        {right}
+      </div>
+    </header>
+  );
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,29 +1,19 @@
-import styles from "./Header.module.css";
+import styles from './Header.module.css'
 
 interface HeaderProps {
-  title: string;
-  left?: React.ReactNode;
-  right?: React.ReactNode;
+  title: string
+  left?: React.ReactNode
+  right?: React.ReactNode
 }
 
-export default function Header({
-  title,
-  left,
-  right,
-}: HeaderProps) {
+export default function Header({ title, left, right }: HeaderProps) {
   return (
     <header className={styles.header}>
-      <div className={styles.left}>
-        {left}
-      </div>
+      <div className={styles.left}>{left}</div>
 
-      <h1 className={styles.title}>
-        {title}
-      </h1>
+      <h1 className={styles.title}>{title}</h1>
 
-      <div className={styles.right}>
-        {right}
-      </div>
+      <div className={styles.right}>{right}</div>
     </header>
-  );
+  )
 }

--- a/src/components/Header/index.ts
+++ b/src/components/Header/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Header";

--- a/src/components/Header/index.ts
+++ b/src/components/Header/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Header";
+export { default } from './Header'

--- a/src/features/record/components/DateSection/DateSection.module.css
+++ b/src/features/record/components/DateSection/DateSection.module.css
@@ -1,22 +1,21 @@
 .section {
-    display: flex;
-    flex-direction: column;
-  }
-  
-  .date {
-    margin: 0;
-  
-    color: var(--Text-Primary, #243130);
-    font-family: Pretendard;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: 500;
-    line-height: normal;
+  display: flex;
+  flex-direction: column;
+}
 
-  }
-  
-  .list {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
+.date {
+  margin: 0;
+
+  color: var(--Text-Primary, #243130);
+  font-family: Pretendard;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/features/record/components/DateSection/DateSection.module.css
+++ b/src/features/record/components/DateSection/DateSection.module.css
@@ -5,7 +5,6 @@
 
 .date {
   margin: 0;
-
   color: var(--Text-Primary, #243130);
   font-family: Pretendard;
   font-size: 14px;

--- a/src/features/record/components/DateSection/DateSection.module.css
+++ b/src/features/record/components/DateSection/DateSection.module.css
@@ -1,0 +1,22 @@
+.section {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  .date {
+    margin: 0;
+  
+    color: var(--Text-Primary, #243130);
+    font-family: Pretendard;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+
+  }
+  
+  .list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }

--- a/src/features/record/components/DateSection/DateSection.tsx
+++ b/src/features/record/components/DateSection/DateSection.tsx
@@ -1,0 +1,21 @@
+import styles from "./DateSection.module.css";
+
+interface DateSectionProps {
+  date: string;
+  children: React.ReactNode;
+}
+
+export default function DateSection({
+  date,
+  children,
+}: DateSectionProps) {
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.date}>{date}</h2>
+
+      <div className={styles.list}>
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/src/features/record/components/DateSection/DateSection.tsx
+++ b/src/features/record/components/DateSection/DateSection.tsx
@@ -1,21 +1,16 @@
-import styles from "./DateSection.module.css";
+import styles from './DateSection.module.css'
 
 interface DateSectionProps {
-  date: string;
-  children: React.ReactNode;
+  date: string
+  children: React.ReactNode
 }
 
-export default function DateSection({
-  date,
-  children,
-}: DateSectionProps) {
+export default function DateSection({ date, children }: DateSectionProps) {
   return (
     <section className={styles.section}>
       <h2 className={styles.date}>{date}</h2>
 
-      <div className={styles.list}>
-        {children}
-      </div>
+      <div className={styles.list}>{children}</div>
     </section>
-  );
+  )
 }

--- a/src/features/record/components/DateSection/index.ts
+++ b/src/features/record/components/DateSection/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./DateSection";
+export { default } from './DateSection'

--- a/src/features/record/components/DateSection/index.ts
+++ b/src/features/record/components/DateSection/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DateSection";

--- a/src/features/record/components/FilterChip/FilterChip.module.css
+++ b/src/features/record/components/FilterChip/FilterChip.module.css
@@ -1,26 +1,25 @@
 .chip {
-    height: 30px;
-    padding: 0 10px;
-  
-    border-radius: 15px;
-    border: 1px solid var(--color-main-500, #2F7F82);
-    background: var(--color-text-white, #FEFEFE);
-  
-    color: var(--color-main-500, #2F7F82);
-  
-    font-size: 12px;
-    font-weight: 600;
-  
-    cursor: pointer;
-    transition: 0.2s ease;
-  
-    display: flex;
-    justify-content: center;
-    align-items: center;
+  height: 30px;
+  padding: 0 10px;
 
-  }
-  
-  .selected {
-    background: var(--color-main-500, #2F7F82);
-    color: var(--color-text-white, #FEFEFE);
-  }
+  border-radius: 15px;
+  border: 1px solid var(--color-main-500, #2f7f82);
+  background: var(--color-text-white, #fefefe);
+
+  color: var(--color-main-500, #2f7f82);
+
+  font-size: 12px;
+  font-weight: 600;
+
+  cursor: pointer;
+  transition: 0.2s ease;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.selected {
+  background: var(--color-main-500, #2f7f82);
+  color: var(--color-text-white, #fefefe);
+}

--- a/src/features/record/components/FilterChip/FilterChip.module.css
+++ b/src/features/record/components/FilterChip/FilterChip.module.css
@@ -1,19 +1,14 @@
 .chip {
   height: 30px;
   padding: 0 10px;
-
   border-radius: 15px;
   border: 1px solid var(--color-main-500, #2f7f82);
   background: var(--color-text-white, #fefefe);
-
   color: var(--color-main-500, #2f7f82);
-
   font-size: 12px;
   font-weight: 600;
-
   cursor: pointer;
   transition: 0.2s ease;
-
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/features/record/components/FilterChip/FilterChip.module.css
+++ b/src/features/record/components/FilterChip/FilterChip.module.css
@@ -1,0 +1,26 @@
+.chip {
+    height: 30px;
+    padding: 0 10px;
+  
+    border-radius: 15px;
+    border: 1px solid var(--color-main-500, #2F7F82);
+    background: var(--color-text-white, #FEFEFE);
+  
+    color: var(--color-main-500, #2F7F82);
+  
+    font-size: 12px;
+    font-weight: 600;
+  
+    cursor: pointer;
+    transition: 0.2s ease;
+  
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+  }
+  
+  .selected {
+    background: var(--color-main-500, #2F7F82);
+    color: var(--color-text-white, #FEFEFE);
+  }

--- a/src/features/record/components/FilterChip/FilterChip.tsx
+++ b/src/features/record/components/FilterChip/FilterChip.tsx
@@ -8,7 +8,11 @@ interface FilterChipProps {
 
 export default function FilterChip({ label, selected = false, onClick }: FilterChipProps) {
   return (
-    <button className={`${styles.chip} ${selected ? styles.selected : ''}`} onClick={onClick}>
+    <button
+      type="button"
+      className={`${styles.chip} ${selected ? styles.selected : ''}`}
+      onClick={onClick}
+    >
       {label}
     </button>
   )

--- a/src/features/record/components/FilterChip/FilterChip.tsx
+++ b/src/features/record/components/FilterChip/FilterChip.tsx
@@ -1,0 +1,22 @@
+import styles from "./FilterChip.module.css";
+
+interface FilterChipProps {
+  label: string;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+export default function FilterChip({
+  label,
+  selected = false,
+  onClick,
+}: FilterChipProps) {
+  return (
+    <button
+      className={`${styles.chip} ${selected ? styles.selected : ""}`}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/features/record/components/FilterChip/FilterChip.tsx
+++ b/src/features/record/components/FilterChip/FilterChip.tsx
@@ -1,22 +1,15 @@
-import styles from "./FilterChip.module.css";
+import styles from './FilterChip.module.css'
 
 interface FilterChipProps {
-  label: string;
-  selected?: boolean;
-  onClick?: () => void;
+  label: string
+  selected?: boolean
+  onClick?: () => void
 }
 
-export default function FilterChip({
-  label,
-  selected = false,
-  onClick,
-}: FilterChipProps) {
+export default function FilterChip({ label, selected = false, onClick }: FilterChipProps) {
   return (
-    <button
-      className={`${styles.chip} ${selected ? styles.selected : ""}`}
-      onClick={onClick}
-    >
+    <button className={`${styles.chip} ${selected ? styles.selected : ''}`} onClick={onClick}>
       {label}
     </button>
-  );
+  )
 }

--- a/src/features/record/components/FilterChip/index.ts
+++ b/src/features/record/components/FilterChip/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./FilterChip";

--- a/src/features/record/components/FilterChip/index.ts
+++ b/src/features/record/components/FilterChip/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./FilterChip";
+export { default } from './FilterChip'

--- a/src/features/record/components/RecordCard/RecordCard.module.css
+++ b/src/features/record/components/RecordCard/RecordCard.module.css
@@ -1,79 +1,78 @@
 .card {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  
-    width: 100%;
-    padding: 8px;
-  
-    border-radius: 16px;
-    background: #fdfefe;
-    
-  }
-  
-  .left {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-  
-  .thumbnail,
-  .thumbnailPlaceholder {
-    width: 46px;
-    height: 46px;
-  
-    border-radius: 7px;
-  
-    background: #e4e4e4;
-  
-    flex-shrink: 0;
-  }
-  
-  .thumbnail {
-    object-fit: cover;
-  }
-  
-  .info {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-  
-  .title {
-    margin: 0;
-  
-    color: var(--Text-Primary, #243130);
-    font-family: Pretendard;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: 500;
-    line-height: normal;
-  }
-  
-  .category {
-    color: var(--Text-Primary, #243130);
-    font-family: Pretendard;
-    font-size: 12px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
-  }
-  
-  .amount {
-    color: var(--Text-Primary, #243130);
-    text-align: right;
-    font-family: Pretendard;
-    font-size: 17.319px;
-    font-style: normal;
-    font-weight: 500;
-    line-height: normal;
-  }
-  
-  .saved {
-    color: #273233;
-  }
-  
-  .consume {
-    color: #a8afaf;
-    text-decoration-line: line-through;
-  }
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  width: 100%;
+  padding: 8px;
+
+  border-radius: 16px;
+  background: #fdfefe;
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.thumbnail,
+.thumbnailPlaceholder {
+  width: 46px;
+  height: 46px;
+
+  border-radius: 7px;
+
+  background: #e4e4e4;
+
+  flex-shrink: 0;
+}
+
+.thumbnail {
+  object-fit: cover;
+}
+
+.info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  margin: 0;
+
+  color: var(--Text-Primary, #243130);
+  font-family: Pretendard;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}
+
+.category {
+  color: var(--Text-Primary, #243130);
+  font-family: Pretendard;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: normal;
+}
+
+.amount {
+  color: var(--Text-Primary, #243130);
+  text-align: right;
+  font-family: Pretendard;
+  font-size: 17.319px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}
+
+.saved {
+  color: #273233;
+}
+
+.consume {
+  color: #a8afaf;
+  text-decoration-line: line-through;
+}

--- a/src/features/record/components/RecordCard/RecordCard.module.css
+++ b/src/features/record/components/RecordCard/RecordCard.module.css
@@ -1,0 +1,79 @@
+.card {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  
+    width: 100%;
+    padding: 8px;
+  
+    border-radius: 16px;
+    background: #fdfefe;
+    
+  }
+  
+  .left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  
+  .thumbnail,
+  .thumbnailPlaceholder {
+    width: 46px;
+    height: 46px;
+  
+    border-radius: 7px;
+  
+    background: #e4e4e4;
+  
+    flex-shrink: 0;
+  }
+  
+  .thumbnail {
+    object-fit: cover;
+  }
+  
+  .info {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+  
+  .title {
+    margin: 0;
+  
+    color: var(--Text-Primary, #243130);
+    font-family: Pretendard;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+  }
+  
+  .category {
+    color: var(--Text-Primary, #243130);
+    font-family: Pretendard;
+    font-size: 12px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+  }
+  
+  .amount {
+    color: var(--Text-Primary, #243130);
+    text-align: right;
+    font-family: Pretendard;
+    font-size: 17.319px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+  }
+  
+  .saved {
+    color: #273233;
+  }
+  
+  .consume {
+    color: #a8afaf;
+    text-decoration-line: line-through;
+  }

--- a/src/features/record/components/RecordCard/RecordCard.tsx
+++ b/src/features/record/components/RecordCard/RecordCard.tsx
@@ -1,15 +1,15 @@
-import { Link } from "react-router-dom";
-import styles from "./RecordCard.module.css";
+import { Link } from 'react-router-dom'
+import styles from './RecordCard.module.css'
 
-export type RecordType = "saved" | "consume";
+export type RecordType = 'saved' | 'consume'
 
 interface RecordCardProps {
-  id: string;
-  title: string;
-  category: string;
-  amount: number;
-  type: RecordType;
-  thumbnail?: string;
+  id: string
+  title: string
+  category: string
+  amount: number
+  type: RecordType
+  thumbnail?: string
 }
 
 export default function RecordCard({
@@ -35,13 +35,9 @@ export default function RecordCard({
         </div>
       </div>
 
-      <p
-        className={`${styles.amount} ${
-          type === "saved" ? styles.saved : styles.consume
-        }`}
-      >
-        {type === "saved" ? "+" : "-"} {amount.toLocaleString()}원
+      <p className={`${styles.amount} ${type === 'saved' ? styles.saved : styles.consume}`}>
+        {type === 'saved' ? '+' : '-'} {amount.toLocaleString()}원
       </p>
     </Link>
-  );
+  )
 }

--- a/src/features/record/components/RecordCard/RecordCard.tsx
+++ b/src/features/record/components/RecordCard/RecordCard.tsx
@@ -1,0 +1,44 @@
+import styles from "./RecordCard.module.css";
+
+export type RecordType = "saved" | "consume";
+
+interface RecordCardProps {
+  title: string;
+  category: string;
+  amount: number;
+  type: RecordType;
+  thumbnail?: string;
+}
+
+export default function RecordCard({
+  title,
+  category,
+  amount,
+  type,
+  thumbnail,
+}: RecordCardProps) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.left}>
+        {thumbnail ? (
+          <img src={thumbnail} alt={title} className={styles.thumbnail} />
+        ) : (
+          <div className={styles.thumbnailPlaceholder} />
+        )}
+
+        <div className={styles.info}>
+          <p className={styles.title}>{title}</p>
+          <p className={styles.category}>{category}</p>
+        </div>
+      </div>
+
+      <p
+        className={`${styles.amount} ${
+          type === "saved" ? styles.saved : styles.consume
+        }`}
+      >
+        {type === "saved" ? "+" : "-"} {amount.toLocaleString()}원
+      </p>
+    </div>
+  );
+}

--- a/src/features/record/components/RecordCard/RecordCard.tsx
+++ b/src/features/record/components/RecordCard/RecordCard.tsx
@@ -1,8 +1,10 @@
+import { Link } from "react-router-dom";
 import styles from "./RecordCard.module.css";
 
 export type RecordType = "saved" | "consume";
 
 interface RecordCardProps {
+  id: string;
   title: string;
   category: string;
   amount: number;
@@ -11,6 +13,7 @@ interface RecordCardProps {
 }
 
 export default function RecordCard({
+  id,
   title,
   category,
   amount,
@@ -18,7 +21,7 @@ export default function RecordCard({
   thumbnail,
 }: RecordCardProps) {
   return (
-    <div className={styles.card}>
+    <Link to={`/record/${id}`} className={styles.card}>
       <div className={styles.left}>
         {thumbnail ? (
           <img src={thumbnail} alt={title} className={styles.thumbnail} />
@@ -39,6 +42,6 @@ export default function RecordCard({
       >
         {type === "saved" ? "+" : "-"} {amount.toLocaleString()}원
       </p>
-    </div>
+    </Link>
   );
 }

--- a/src/features/record/components/RecordCard/index.ts
+++ b/src/features/record/components/RecordCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./RecordCard";
+export type { RecordType } from "./RecordCard";

--- a/src/features/record/components/RecordCard/index.ts
+++ b/src/features/record/components/RecordCard/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./RecordCard";
-export type { RecordType } from "./RecordCard";
+export { default } from './RecordCard'
+export type { RecordType } from './RecordCard'

--- a/src/features/record/components/RecordList/RecordList.module.css
+++ b/src/features/record/components/RecordList/RecordList.module.css
@@ -1,0 +1,8 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+  
+    padding: 0 37px 126px;
+
+  }

--- a/src/features/record/components/RecordList/RecordList.module.css
+++ b/src/features/record/components/RecordList/RecordList.module.css
@@ -1,8 +1,7 @@
 .container {
-    display: flex;
-    flex-direction: column;
-    gap: 32px;
-  
-    padding: 0 37px 126px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 
-  }
+  padding: 0 37px 126px;
+}

--- a/src/features/record/components/RecordList/RecordList.tsx
+++ b/src/features/record/components/RecordList/RecordList.tsx
@@ -6,6 +6,7 @@ import type { RecordType } from "../RecordCard";
 export type FilterValue = "all" | RecordType;
 
 interface Record {
+  id: string;
   title: string;
   category: string;
   amount: number;
@@ -23,12 +24,14 @@ const mockData: RecordGroup[] = [
     date: "2026년 4월 17일",
     records: [
       {
+        id: "1",
         title: "투썸플레이스 신봉점",
         category: "카페/디저트",
         amount: 6100,
         type: "saved",
       },
       {
+        id: "2",
         title: "ZARA 반팔티",
         category: "의류",
         amount: 23900,
@@ -40,6 +43,7 @@ const mockData: RecordGroup[] = [
     date: "2026년 4월 14일",
     records: [
       {
+        id: "3",
         title: "무신사",
         category: "패션",
         amount: 35000,
@@ -68,9 +72,10 @@ export default function RecordList({ filter }: RecordListProps) {
     <div className={styles.container}>
       {filteredData.map((group) => (
         <DateSection key={group.date} date={group.date}>
-          {group.records.map((record, index) => (
+          {group.records.map((record) => (
             <RecordCard
-              key={index}
+              key={record.id}
+              id={record.id}
               title={record.title}
               category={record.category}
               amount={record.amount}

--- a/src/features/record/components/RecordList/RecordList.tsx
+++ b/src/features/record/components/RecordList/RecordList.tsx
@@ -1,61 +1,61 @@
-import styles from "./RecordList.module.css";
-import DateSection from "../DateSection";
-import RecordCard from "../RecordCard";
-import type { RecordType } from "../RecordCard";
+import styles from './RecordList.module.css'
+import DateSection from '../DateSection'
+import RecordCard from '../RecordCard'
+import type { RecordType } from '../RecordCard'
 
-export type FilterValue = "all" | RecordType;
+export type FilterValue = 'all' | RecordType
 
 interface Record {
-  id: string;
-  title: string;
-  category: string;
-  amount: number;
-  type: RecordType;
-  thumbnail?: string;
+  id: string
+  title: string
+  category: string
+  amount: number
+  type: RecordType
+  thumbnail?: string
 }
 
 interface RecordGroup {
-  date: string;
-  records: Record[];
+  date: string
+  records: Record[]
 }
 
 // 하드코딩됨. API 연결 시 수정 예정
 const mockData: RecordGroup[] = [
   {
-    date: "2026년 4월 17일",
+    date: '2026년 4월 17일',
     records: [
       {
-        id: "1",
-        title: "투썸플레이스 신봉점",
-        category: "카페/디저트",
+        id: '1',
+        title: '투썸플레이스 신봉점',
+        category: '카페/디저트',
         amount: 6100,
-        type: "saved",
+        type: 'saved',
       },
       {
-        id: "2",
-        title: "ZARA 반팔티",
-        category: "의류",
+        id: '2',
+        title: 'ZARA 반팔티',
+        category: '의류',
         amount: 23900,
-        type: "consume",
+        type: 'consume',
       },
     ],
   },
   {
-    date: "2026년 4월 14일",
+    date: '2026년 4월 14일',
     records: [
       {
-        id: "3",
-        title: "무신사",
-        category: "패션",
+        id: '3',
+        title: '무신사',
+        category: '패션',
         amount: 35000,
-        type: "saved",
+        type: 'saved',
       },
     ],
   },
-];
+]
 
 interface RecordListProps {
-  filter: FilterValue;
+  filter: FilterValue
 }
 
 export default function RecordList({ filter }: RecordListProps) {
@@ -63,11 +63,9 @@ export default function RecordList({ filter }: RecordListProps) {
     .map((group) => ({
       ...group,
       records:
-        filter === "all"
-          ? group.records
-          : group.records.filter((record) => record.type === filter),
+        filter === 'all' ? group.records : group.records.filter((record) => record.type === filter),
     }))
-    .filter((group) => group.records.length > 0);
+    .filter((group) => group.records.length > 0)
 
   return (
     <div className={styles.container}>
@@ -87,5 +85,5 @@ export default function RecordList({ filter }: RecordListProps) {
         </DateSection>
       ))}
     </div>
-  );
+  )
 }

--- a/src/features/record/components/RecordList/RecordList.tsx
+++ b/src/features/record/components/RecordList/RecordList.tsx
@@ -3,6 +3,8 @@ import DateSection from "../DateSection";
 import RecordCard from "../RecordCard";
 import type { RecordType } from "../RecordCard";
 
+export type FilterValue = "all" | RecordType;
+
 interface Record {
   title: string;
   category: string;
@@ -47,10 +49,24 @@ const mockData: RecordGroup[] = [
   },
 ];
 
-export default function RecordList() {
+interface RecordListProps {
+  filter: FilterValue;
+}
+
+export default function RecordList({ filter }: RecordListProps) {
+  const filteredData = mockData
+    .map((group) => ({
+      ...group,
+      records:
+        filter === "all"
+          ? group.records
+          : group.records.filter((record) => record.type === filter),
+    }))
+    .filter((group) => group.records.length > 0);
+
   return (
     <div className={styles.container}>
-      {mockData.map((group) => (
+      {filteredData.map((group) => (
         <DateSection key={group.date} date={group.date}>
           {group.records.map((record, index) => (
             <RecordCard

--- a/src/features/record/components/RecordList/RecordList.tsx
+++ b/src/features/record/components/RecordList/RecordList.tsx
@@ -5,7 +5,7 @@ import type { RecordType } from '../RecordCard'
 
 export type FilterValue = 'all' | RecordType
 
-interface Record {
+interface RecordItem {
   id: string
   title: string
   category: string
@@ -16,7 +16,7 @@ interface Record {
 
 interface RecordGroup {
   date: string
-  records: Record[]
+  records: RecordItem[]
 }
 
 // 하드코딩됨. API 연결 시 수정 예정

--- a/src/features/record/components/RecordList/RecordList.tsx
+++ b/src/features/record/components/RecordList/RecordList.tsx
@@ -19,6 +19,7 @@ interface RecordGroup {
   records: Record[];
 }
 
+// 하드코딩됨. API 연결 시 수정 예정
 const mockData: RecordGroup[] = [
   {
     date: "2026년 4월 17일",

--- a/src/features/record/components/RecordList/RecordList.tsx
+++ b/src/features/record/components/RecordList/RecordList.tsx
@@ -1,0 +1,69 @@
+import styles from "./RecordList.module.css";
+import DateSection from "../DateSection";
+import RecordCard from "../RecordCard";
+import type { RecordType } from "../RecordCard";
+
+interface Record {
+  title: string;
+  category: string;
+  amount: number;
+  type: RecordType;
+  thumbnail?: string;
+}
+
+interface RecordGroup {
+  date: string;
+  records: Record[];
+}
+
+const mockData: RecordGroup[] = [
+  {
+    date: "2026년 4월 17일",
+    records: [
+      {
+        title: "투썸플레이스 신봉점",
+        category: "카페/디저트",
+        amount: 6100,
+        type: "saved",
+      },
+      {
+        title: "ZARA 반팔티",
+        category: "의류",
+        amount: 23900,
+        type: "consume",
+      },
+    ],
+  },
+  {
+    date: "2026년 4월 14일",
+    records: [
+      {
+        title: "무신사",
+        category: "패션",
+        amount: 35000,
+        type: "saved",
+      },
+    ],
+  },
+];
+
+export default function RecordList() {
+  return (
+    <div className={styles.container}>
+      {mockData.map((group) => (
+        <DateSection key={group.date} date={group.date}>
+          {group.records.map((record, index) => (
+            <RecordCard
+              key={index}
+              title={record.title}
+              category={record.category}
+              amount={record.amount}
+              type={record.type}
+              thumbnail={record.thumbnail}
+            />
+          ))}
+        </DateSection>
+      ))}
+    </div>
+  );
+}

--- a/src/features/record/components/RecordList/index.ts
+++ b/src/features/record/components/RecordList/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RecordList";

--- a/src/features/record/components/RecordList/index.ts
+++ b/src/features/record/components/RecordList/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./RecordList";
+export type { FilterValue } from "./RecordList";

--- a/src/features/record/components/RecordList/index.ts
+++ b/src/features/record/components/RecordList/index.ts
@@ -1,2 +1,2 @@
-export { default } from "./RecordList";
-export type { FilterValue } from "./RecordList";
+export { default } from './RecordList'
+export type { FilterValue } from './RecordList'

--- a/src/features/record/components/SummaryCard/SummaryCard.module.css
+++ b/src/features/record/components/SummaryCard/SummaryCard.module.css
@@ -1,12 +1,9 @@
 .summary {
   width: 100%;
   height: 200px;
-
   padding: 24px 40px;
   box-sizing: border-box;
-
   background: var(--color-main-000, #f7fbfa);
-
   border-radius: 0 0 20px 20px;
   box-shadow: 0px 4px 4px rgba(56, 150, 152, 0.25);
 }
@@ -14,7 +11,6 @@
 .card {
   width: 100%;
   height: 100%;
-
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -32,7 +28,6 @@
   font-style: normal;
   font-weight: 600;
   line-height: normal;
-
   color: var(--Text-Primary, #243130);
 }
 
@@ -47,10 +42,8 @@
 
 .legendWrapper {
   position: relative;
-
   width: 244px;
   height: 73px;
-
   margin-top: 12px;
 }
 
@@ -64,13 +57,10 @@
 .legend {
   position: relative;
   z-index: 1;
-
   width: 100%;
   height: 100%;
-
   padding: 13px 80px 14px 24px;
   box-sizing: border-box;
-
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -81,7 +71,6 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-
   color: var(--Text-Primary, #243130);
   font-family: Pretendard;
   font-size: 14px;
@@ -99,7 +88,6 @@
 .percent {
   margin-left: auto;
   margin-right: 20px;
-
   color: var(--Text-Primary, #243130);
   font-family: Pretendard;
   font-size: 14px;
@@ -111,7 +99,6 @@
 .dot {
   width: 10px;
   height: 10px;
-
   border-radius: 50%;
 }
 
@@ -126,13 +113,10 @@
 .chart {
   width: 120px;
   height: 120px;
-
   border-radius: 50%;
   border: 2px dashed #cfd8dc;
-
   display: flex;
   justify-content: center;
   align-items: center;
-
   color: #999;
 }

--- a/src/features/record/components/SummaryCard/SummaryCard.module.css
+++ b/src/features/record/components/SummaryCard/SummaryCard.module.css
@@ -5,7 +5,7 @@
   padding: 24px 40px;
   box-sizing: border-box;
 
-  background: var(--color-main-000, #F7FBFA);
+  background: var(--color-main-000, #f7fbfa);
 
   border-radius: 0 0 20px 20px;
   box-shadow: 0px 4px 4px rgba(56, 150, 152, 0.25);
@@ -37,51 +37,50 @@
 }
 
 .price {
-
-    color: var(--Text-Primary, #243130);
-    font-family: Pretendard;
-    font-size: 24px;
-    font-style: normal;
-    font-weight: 600;
-    line-height: normal;
+  color: var(--Text-Primary, #243130);
+  font-family: Pretendard;
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
 }
 
 .legendWrapper {
-    position: relative;
-  
-    width: 244px;
-    height: 73px;
-  
-    margin-top: 12px;
+  position: relative;
+
+  width: 244px;
+  height: 73px;
+
+  margin-top: 12px;
 }
 
 .legendBg {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .legend {
-    position: relative;
-    z-index: 1;
-  
-    width: 100%;
-    height: 100%;
-  
-    padding: 13px 80px 14px 24px;
-    box-sizing: border-box;
-  
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    gap: 12px;
-  }
+  position: relative;
+  z-index: 1;
+
+  width: 100%;
+  height: 100%;
+
+  padding: 13px 80px 14px 24px;
+  box-sizing: border-box;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 12px;
+}
 
 .legendItem {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
   color: var(--Text-Primary, #243130);
   font-family: Pretendard;
@@ -92,22 +91,21 @@
 }
 
 .leftItem {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 
 .percent {
+  margin-left: auto;
+  margin-right: 20px;
 
-    margin-left: auto;
-    margin-right: 20px; 
-
-    color: var(--Text-Primary, #243130);
-    font-family: Pretendard;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: 500;
-    line-height: normal;
+  color: var(--Text-Primary, #243130);
+  font-family: Pretendard;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
 }
 
 .dot {
@@ -118,7 +116,7 @@
 }
 
 .consume {
-  background: var(--color-gray-300, #5B6B6A);
+  background: var(--color-gray-300, #5b6b6a);
 }
 
 .save {

--- a/src/features/record/components/SummaryCard/SummaryCard.module.css
+++ b/src/features/record/components/SummaryCard/SummaryCard.module.css
@@ -1,0 +1,140 @@
+.summary {
+  width: 100%;
+  height: 200px;
+
+  padding: 24px 40px;
+  box-sizing: border-box;
+
+  background: var(--color-main-000, #F7FBFA);
+
+  border-radius: 0 0 20px 20px;
+  box-shadow: 0px 4px 4px rgba(56, 150, 152, 0.25);
+}
+
+.card {
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.left {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title {
+  font-family: Pretendard;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+
+  color: var(--Text-Primary, #243130);
+}
+
+.price {
+
+    color: var(--Text-Primary, #243130);
+    font-family: Pretendard;
+    font-size: 24px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+}
+
+.legendWrapper {
+    position: relative;
+  
+    width: 244px;
+    height: 73px;
+  
+    margin-top: 12px;
+}
+
+.legendBg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.legend {
+    position: relative;
+    z-index: 1;
+  
+    width: 100%;
+    height: 100%;
+  
+    padding: 13px 80px 14px 24px;
+    box-sizing: border-box;
+  
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 12px;
+  }
+
+.legendItem {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+  color: var(--Text-Primary, #243130);
+  font-family: Pretendard;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+}
+
+.leftItem {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+.percent {
+
+    margin-left: auto;
+    margin-right: 20px; 
+
+    color: var(--Text-Primary, #243130);
+    font-family: Pretendard;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: normal;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+
+  border-radius: 50%;
+}
+
+.consume {
+  background: var(--color-gray-300, #5B6B6A);
+}
+
+.save {
+  background: var(--color-main-400, #389698);
+}
+
+.chart {
+  width: 120px;
+  height: 120px;
+
+  border-radius: 50%;
+  border: 2px dashed #cfd8dc;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  color: #999;
+}

--- a/src/features/record/components/SummaryCard/SummaryCard.tsx
+++ b/src/features/record/components/SummaryCard/SummaryCard.tsx
@@ -1,5 +1,5 @@
-import styles from "./SummaryCard.module.css";
-import legendBg from "@/assets/legend-bg.svg";
+import styles from './SummaryCard.module.css'
+import legendBg from '@/assets/legend-bg.svg'
 
 export default function SummaryCard() {
   // 하드코딩됨. API 연결 시 수정 예정
@@ -12,11 +12,7 @@ export default function SummaryCard() {
           <h2 className={styles.price}>+96,500원</h2>
 
           <div className={styles.legendWrapper}>
-            <img
-              src={legendBg}
-              alt=""
-              className={styles.legendBg}
-            />
+            <img src={legendBg} alt="" className={styles.legendBg} />
 
             <div className={styles.legend}>
               <div className={styles.legendItem}>
@@ -40,10 +36,8 @@ export default function SummaryCard() {
           </div>
         </div>
 
-        <div className={styles.chart}>
-          Chart
-        </div>
+        <div className={styles.chart}>Chart</div>
       </div>
     </section>
-  );
+  )
 }

--- a/src/features/record/components/SummaryCard/SummaryCard.tsx
+++ b/src/features/record/components/SummaryCard/SummaryCard.tsx
@@ -1,0 +1,48 @@
+import styles from "./SummaryCard.module.css";
+import legendBg from "@/assets/legend-bg.svg";
+
+export default function SummaryCard() {
+  return (
+    <section className={styles.summary}>
+      <div className={styles.card}>
+        <div className={styles.left}>
+          <p className={styles.title}>소비 vs 참은 소비</p>
+
+          <h2 className={styles.price}>+96,500원</h2>
+
+          <div className={styles.legendWrapper}>
+            <img
+              src={legendBg}
+              alt=""
+              className={styles.legendBg}
+            />
+
+            <div className={styles.legend}>
+              <div className={styles.legendItem}>
+                <div className={styles.leftItem}>
+                  <span className={`${styles.dot} ${styles.save}`} />
+                  <span>참았어요</span>
+                </div>
+
+                <span className={styles.percent}>65%</span>
+              </div>
+
+              <div className={styles.legendItem}>
+                <div className={styles.leftItem}>
+                  <span className={`${styles.dot} ${styles.consume}`} />
+                  <span>샀어요</span>
+                </div>
+
+                <span className={styles.percent}>35%</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.chart}>
+          Chart
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/record/components/SummaryCard/SummaryCard.tsx
+++ b/src/features/record/components/SummaryCard/SummaryCard.tsx
@@ -2,6 +2,7 @@ import styles from "./SummaryCard.module.css";
 import legendBg from "@/assets/legend-bg.svg";
 
 export default function SummaryCard() {
+  // 하드코딩됨. API 연결 시 수정 예정
   return (
     <section className={styles.summary}>
       <div className={styles.card}>

--- a/src/features/record/components/SummaryCard/index.ts
+++ b/src/features/record/components/SummaryCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SummaryCard";

--- a/src/features/record/components/SummaryCard/index.ts
+++ b/src/features/record/components/SummaryCard/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./SummaryCard";
+export { default } from './SummaryCard'

--- a/src/features/record/pages/RecordDetailPage.tsx
+++ b/src/features/record/pages/RecordDetailPage.tsx
@@ -1,0 +1,13 @@
+import { useParams } from "react-router-dom";
+import Header from "@/components/Header";
+
+export default function RecordDetailPage() {
+  const { id } = useParams<{ id: string }>();
+
+  return (
+    <div>
+      <Header title="소비 상세" />
+      <p>id: {id}</p>
+    </div>
+  );
+}

--- a/src/features/record/pages/RecordDetailPage.tsx
+++ b/src/features/record/pages/RecordDetailPage.tsx
@@ -1,8 +1,8 @@
-import { useParams } from "react-router-dom";
-import Header from "@/components/Header";
+import { useParams } from 'react-router-dom'
+import Header from '@/components/Header'
 
 export default function RecordDetailPage() {
-  const { id } = useParams<{ id: string }>();
+  const { id } = useParams<{ id: string }>()
 
   // 하드코딩됨. API 연결 시 id로 상세 데이터 조회하도록 수정 예정
   return (
@@ -10,5 +10,5 @@ export default function RecordDetailPage() {
       <Header title="소비 상세" />
       <p>id: {id}</p>
     </div>
-  );
+  )
 }

--- a/src/features/record/pages/RecordDetailPage.tsx
+++ b/src/features/record/pages/RecordDetailPage.tsx
@@ -4,6 +4,7 @@ import Header from "@/components/Header";
 export default function RecordDetailPage() {
   const { id } = useParams<{ id: string }>();
 
+  // 하드코딩됨. API 연결 시 id로 상세 데이터 조회하도록 수정 예정
   return (
     <div>
       <Header title="소비 상세" />

--- a/src/features/record/pages/RecordMainPage.tsx
+++ b/src/features/record/pages/RecordMainPage.tsx
@@ -1,40 +1,39 @@
-import { useState } from "react";
-import Header from "@/components/Header";
-import SummaryCard from "@/features/record/components/SummaryCard";
-import FilterChip from "@/features/record/components/FilterChip";
-import RecordList from "@/features/record/components/RecordList";
-import type { FilterValue } from "@/features/record/components/RecordList";
-import styles from "../styles/RecordMainPage.module.css";
+import { useState } from 'react'
+import Header from '@/components/Header'
+import SummaryCard from '@/features/record/components/SummaryCard'
+import FilterChip from '@/features/record/components/FilterChip'
+import RecordList from '@/features/record/components/RecordList'
+import type { FilterValue } from '@/features/record/components/RecordList'
+import styles from '../styles/RecordMainPage.module.css'
 
 const FILTERS: { label: string; value: FilterValue }[] = [
-  { label: "전체", value: "all" },
-  { label: "참은 소비", value: "saved" },
-  { label: "소비", value: "consume" },
-];
+  { label: '전체', value: 'all' },
+  { label: '참은 소비', value: 'saved' },
+  { label: '소비', value: 'consume' },
+]
 
 export default function RecordMainPage() {
-    const [filter, setFilter] = useState<FilterValue>("all");
+  const [filter, setFilter] = useState<FilterValue>('all')
 
-    return (
-        <div className={styles.container}>
-          <Header title="소비 기록" />
+  return (
+    <div className={styles.container}>
+      <Header title="소비 기록" />
 
-          <SummaryCard />
+      <SummaryCard />
 
-          <div className={styles.filterSection}>
-                {FILTERS.map((f) => (
-                  <FilterChip
-                    key={f.value}
-                    label={f.label}
-                    selected={filter === f.value}
-                    onClick={() => setFilter(f.value)}
-                  />
-                ))}
-            </div>
+      <div className={styles.filterSection}>
+        {FILTERS.map((f) => (
+          <FilterChip
+            key={f.value}
+            label={f.label}
+            selected={filter === f.value}
+            onClick={() => setFilter(f.value)}
+          />
+        ))}
+      </div>
 
-          {/* Record List */}
-          <RecordList filter={filter} />
-
-        </div>
-      );
+      {/* Record List */}
+      <RecordList filter={filter} />
+    </div>
+  )
 }

--- a/src/features/record/pages/RecordMainPage.tsx
+++ b/src/features/record/pages/RecordMainPage.tsx
@@ -1,24 +1,39 @@
+import { useState } from "react";
 import Header from "@/components/Header";
 import SummaryCard from "@/features/record/components/SummaryCard";
 import FilterChip from "@/features/record/components/FilterChip";
 import RecordList from "@/features/record/components/RecordList";
+import type { FilterValue } from "@/features/record/components/RecordList";
 import styles from "../styles/RecordMainPage.module.css";
 
+const FILTERS: { label: string; value: FilterValue }[] = [
+  { label: "전체", value: "all" },
+  { label: "참은 소비", value: "saved" },
+  { label: "소비", value: "consume" },
+];
+
 export default function RecordMainPage() {
+    const [filter, setFilter] = useState<FilterValue>("all");
+
     return (
         <div className={styles.container}>
           <Header title="소비 기록" />
-    
+
           <SummaryCard />
-          
+
           <div className={styles.filterSection}>
-                <FilterChip label="전체" selected />
-                <FilterChip label="참은 소비" />
-                <FilterChip label="소비" />
+                {FILTERS.map((f) => (
+                  <FilterChip
+                    key={f.value}
+                    label={f.label}
+                    selected={filter === f.value}
+                    onClick={() => setFilter(f.value)}
+                  />
+                ))}
             </div>
-          
+
           {/* Record List */}
-          <RecordList />
+          <RecordList filter={filter} />
 
         </div>
       );

--- a/src/features/record/pages/RecordMainPage.tsx
+++ b/src/features/record/pages/RecordMainPage.tsx
@@ -1,0 +1,25 @@
+import Header from "@/components/Header";
+import SummaryCard from "@/features/record/components/SummaryCard";
+import FilterChip from "@/features/record/components/FilterChip";
+import RecordList from "@/features/record/components/RecordList";
+import styles from "../styles/RecordMainPage.module.css";
+
+export default function RecordMainPage() {
+    return (
+        <div className={styles.container}>
+          <Header title="소비 기록" />
+    
+          <SummaryCard />
+          
+          <div className={styles.filterSection}>
+                <FilterChip label="전체" selected />
+                <FilterChip label="참은 소비" />
+                <FilterChip label="소비" />
+            </div>
+          
+          {/* Record List */}
+          <RecordList />
+
+        </div>
+      );
+}

--- a/src/features/record/styles/RecordMainPage.module.css
+++ b/src/features/record/styles/RecordMainPage.module.css
@@ -1,0 +1,12 @@
+.container {
+    width: 100%;
+    min-height: 100vh;
+  }
+  
+  .filterSection {
+    display: flex;
+    gap: 8px;
+  
+    padding: 30px 37px 32px;
+
+  }

--- a/src/features/record/styles/RecordMainPage.module.css
+++ b/src/features/record/styles/RecordMainPage.module.css
@@ -6,6 +6,5 @@
 .filterSection {
   display: flex;
   gap: 8px;
-
   padding: 30px 37px 32px;
 }

--- a/src/features/record/styles/RecordMainPage.module.css
+++ b/src/features/record/styles/RecordMainPage.module.css
@@ -1,12 +1,11 @@
 .container {
-    width: 100%;
-    min-height: 100vh;
-  }
-  
-  .filterSection {
-    display: flex;
-    gap: 8px;
-  
-    padding: 30px 37px 32px;
+  width: 100%;
+  min-height: 100vh;
+}
 
-  }
+.filterSection {
+  display: flex;
+  gap: 8px;
+
+  padding: 30px 37px 32px;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -11,12 +11,12 @@
 
   /* Main */
   --color-main-000: #f7fbfa;
-  --color-main-100: #PLACEHOLDER;
-  --color-main-200: #PLACEHOLDER;
-  --color-main-300: #PLACEHOLDER;
+  --color-main-100: #e6f3f3;
+  --color-main-200: #cde7e7;
+  --color-main-300: #a3d4d4;
   --color-main-400: #389698;
   --color-main-500: #2f7f82;
-  --color-main-600: #PLACEHOLDER;
+  --color-main-600: #246365;
 
   /* Text */
   --color-text-white: #ffffff;

--- a/src/index.css
+++ b/src/index.css
@@ -7,15 +7,15 @@
   /* Gray */
   --color-gray-100: #PLACEHOLDER;
   --color-gray-200: #PLACEHOLDER;
-  --color-gray-300: #PLACEHOLDER;
+  --color-gray-300: #5B6B6A;
 
   /* Main */
-  --color-main-000: #PLACEHOLDER;
+  --color-main-000: #F7FBFA;
   --color-main-100: #PLACEHOLDER;
   --color-main-200: #PLACEHOLDER;
   --color-main-300: #PLACEHOLDER;
-  --color-main-400: #PLACEHOLDER;
-  --color-main-500: #PLACEHOLDER;
+  --color-main-400: #389698;
+  --color-main-500: #2F7F82;
   --color-main-600: #PLACEHOLDER;
 
   /* Text */

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 @theme {
   /* Pretendard */
@@ -7,19 +7,19 @@
   /* Gray */
   --color-gray-100: #PLACEHOLDER;
   --color-gray-200: #PLACEHOLDER;
-  --color-gray-300: #5B6B6A;
+  --color-gray-300: #5b6b6a;
 
   /* Main */
-  --color-main-000: #F7FBFA;
+  --color-main-000: #f7fbfa;
   --color-main-100: #PLACEHOLDER;
   --color-main-200: #PLACEHOLDER;
   --color-main-300: #PLACEHOLDER;
   --color-main-400: #389698;
-  --color-main-500: #2F7F82;
+  --color-main-500: #2f7f82;
   --color-main-600: #PLACEHOLDER;
 
   /* Text */
-  --color-text-white: #FFFFFF;
+  --color-text-white: #ffffff;
   --color-text-primary: #PLACEHOLDER;
   --color-text-green: #PLACEHOLDER;
   --color-text-blue: #PLACEHOLDER;

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,9 +1,13 @@
 import { createBrowserRouter } from 'react-router-dom'
 import HomePage from '@/pages/HomePage'
+import HeaderTestPage from '@/pages/HeaderTestPage'
 
 const router = createBrowserRouter([
   { path: '/', element: <HomePage /> },
+
   // TODO: 랜딩, 로그인, 소비기록, 유혹관리, 마이페이지 라우트 추가
+  { path: "/header", element: <HeaderTestPage /> },
+
 ])
 
 export default router

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,13 +1,9 @@
 import { createBrowserRouter } from 'react-router-dom'
 import HomePage from '@/pages/HomePage'
-import HeaderTestPage from '@/pages/HeaderTestPage'
 
 const router = createBrowserRouter([
   { path: '/', element: <HomePage /> },
-
   // TODO: 랜딩, 로그인, 소비기록, 유혹관리, 마이페이지 라우트 추가
-  { path: "/header", element: <HeaderTestPage /> },
-
 ])
 
 export default router

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,12 +1,14 @@
 import { createBrowserRouter } from 'react-router-dom'
 import HomePage from '@/pages/HomePage'
 import RecordMainPage from '@/features/record/pages/RecordMainPage'
+import RecordDetailPage from '@/features/record/pages/RecordDetailPage'
 
 const router = createBrowserRouter([
   { path: '/', element: <HomePage /> },
 
-  // TODO: 랜딩, 로그인, 소비기록, 유혹관리, 마이페이지 라우트 추가
+  // TODO: 랜딩, 로그인, 유혹관리, 마이페이지 라우트 추가
   { path: '/record', element: <RecordMainPage/> },
+  { path: '/record/:id', element: <RecordDetailPage/> },
 ])
 
 export default router

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -7,8 +7,8 @@ const router = createBrowserRouter([
   { path: '/', element: <HomePage /> },
 
   // TODO: 랜딩, 로그인, 유혹관리, 마이페이지 라우트 추가
-  { path: '/record', element: <RecordMainPage/> },
-  { path: '/record/:id', element: <RecordDetailPage/> },
+  { path: '/record', element: <RecordMainPage /> },
+  { path: '/record/:id', element: <RecordDetailPage /> },
 ])
 
 export default router

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,9 +1,12 @@
 import { createBrowserRouter } from 'react-router-dom'
 import HomePage from '@/pages/HomePage'
+import RecordMainPage from '@/features/record/pages/RecordMainPage'
 
 const router = createBrowserRouter([
   { path: '/', element: <HomePage /> },
+
   // TODO: 랜딩, 로그인, 소비기록, 유혹관리, 마이페이지 라우트 추가
+  { path: '/record', element: <RecordMainPage/> },
 ])
 
 export default router


### PR DESCRIPTION
## 📌 작업 내용
- 소비 기록 메인 페이지 레이아웃 구현 (Header + SummaryCard + FilterChip + RecordList 조립)
- 소비 통계 카드(SummaryCard) UI 구현
- 소비 목록 UI 구현 (DateSection, RecordCard, RecordList)
- 필터 Chip UI 구현 및 클릭 시 선택 색상 변경 + 실제 목록 필터링(전체/참은 소비/소비) 기능 구현
- 더미 데이터 연결
- 소비 기록 카드 클릭 시 id 기반 상세 페이지(`/record/:id`) 이동 기능 구현
<br>

## 📷 스크린 샷
<img height="300" alt="image" src="https://github.com/user-attachments/assets/c31d8b40-2b5f-4648-914b-2cb1578ad4cb" />
<img height="300" alt="image" src="https://github.com/user-attachments/assets/f9c7cd75-0278-4c85-82f3-9f564394c41a" />
<img height="300" alt="image" src="https://github.com/user-attachments/assets/f01433c3-47e7-49aa-b5da-87907b45b9d8" />

</br>

## ⚠️ 참고 사항
- 제가 프론트 파트론 프로젝트 협업이 처음이라 api 연결 전에 단순 화면 구현이 우선순위인지, api 연결 시 변동이 적을 구조로 코딩하는게 우선인지 확신이 서지 않아서 일단은 화면 구현을 우선으로 코드를 짰습니다. (피드백 주시면 반영해서 바로 수정하겠습니다)
- 도넛 차트 삽입 중 오류가 발생해 우선순위를 뒤로 미뤘습니다.
- 공통 Header 컴포넌트 PR이 아직 merge되지 않은 것 같아, 우선 제가 만들어둔 초기 컴포넌트로 반영했습니다. (머지되면 이슈 파서 별도 PR로 반영하겠습니다.)
- 소비 기록 상세 화면으로의 전환까지 연결해뒀습니다. 다만 화면 전환만 연결한 상태라, 상세 화면엔 id 값만 그대로 노출되는 상태입니다.
- API 연결 전까지 하드코딩된 부분에는 `// 하드코딩됨. API 연결 시 수정 예정` 주석을 달아뒀습니다.

</br>


## 🔗 관련 이슈
Closes #13 

</br>
</br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 소비 기록 메인 페이지와 상세 페이지가 추가되어 기록 목록과 개별 항목 확인이 가능해졌습니다.
  * 날짜별로 기록이 그룹으로 나뉘어 표시되고, 항목 카드는 썸네일/금액/상태가 함께 노출됩니다.
  * 상단 필터 칩으로 전체/유형별 기록을 전환해 볼 수 있습니다.
  * 요약 카드(소비/참 비율)가 함께 표시됩니다.
* **Style**
  * 헤더 및 각 컴포넌트 레이아웃/색상 스타일이 갱신되고, Tailwind 테마 색상이 구체화되었습니다.
* **Routing**
  * `/record` 및 `/record/:id` 경로로 화면 이동이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->