### PR TITLE
✨ [Feature] 알림 - 상단 헤더 & 필터 칩 구현

### DIFF
--- a/src/features/notification/components/FilterTabs.module.css
+++ b/src/features/notification/components/FilterTabs.module.css
@@ -1,0 +1,27 @@
+.tabs {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+}
+
+.tab {
+  flex: 1;
+  height: 40px;
+  padding: 0 4px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 400;
+  cursor: pointer;
+  border: none;
+  background: var(--color-main-100);
+  color: var(--color-text-primary);
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tab.active {
+  background: var(--color-main-500);
+  color: var(--color-text-white);
+}

--- a/src/features/notification/components/FilterTabs.tsx
+++ b/src/features/notification/components/FilterTabs.tsx
@@ -1,0 +1,31 @@
+import styles from './FilterTabs.module.css'
+
+export type FilterType = '전체' | '일반' | '목표현황' | '재판단'
+
+const TABS: { label: string; value: FilterType }[] = [
+  { label: '전체 보기', value: '전체' },
+  { label: '일반 알림', value: '일반' },
+  { label: '목표 현황 알림', value: '목표현황' },
+  { label: '재판단 알림', value: '재판단' },
+]
+
+interface FilterTabsProps {
+  active: FilterType
+  onChange: (value: FilterType) => void
+}
+
+export default function FilterTabs({ active, onChange }: FilterTabsProps) {
+  return (
+    <div className={styles.tabs}>
+      {TABS.map(tab => (
+        <button
+          key={tab.value}
+          className={`${styles.tab} ${active === tab.value ? styles.active : ''}`}
+          onClick={() => onChange(tab.value)}
+        >
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/pages/NotificationPage.module.css
+++ b/src/pages/NotificationPage.module.css
@@ -1,0 +1,16 @@
+.logo {
+  font-size: 14px;
+  font-weight: 700;
+  font-style: italic;
+  color: var(--color-text-primary);
+}
+
+.iconBtn {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: var(--color-text-primary);
+  display: flex;
+  align-items: center;
+}

--- a/src/pages/NotificationPage.tsx
+++ b/src/pages/NotificationPage.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { IoChevronBack, IoSettingsOutline } from 'react-icons/io5'
+import Header from '@/components/layout/Header'
+import Notification from '@/features/notification'
+import FilterTabs from '@/features/notification/components/FilterTabs'
+import NotificationSettingsSheet from '@/features/notification/components/NotificationSettingsSheet'
+import type { FilterType } from '@/features/notification/components/FilterTabs'
+import styles from './NotificationPage.module.css'
+
+export default function NotificationPage() {
+  const navigate = useNavigate()
+  const [filter, setFilter] = useState<FilterType>('전체')
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [unreadCount, setUnreadCount] = useState(0)
+
+  return (
+    <>
+      <Header
+        unreadCount={unreadCount}
+        subLeft={
+          <button className={styles.iconBtn} aria-label="뒤로가기" onClick={() => navigate(-1)}>
+            <IoChevronBack size={20} />
+          </button>
+        }
+        subTitle="알림"
+        subRight={
+          <button className={styles.iconBtn} aria-label="설정" onClick={() => setSheetOpen(true)}>
+            <IoSettingsOutline size={20} />
+          </button>
+        }
+        subMain={<FilterTabs active={filter} onChange={setFilter} />}
+      />
+      <Notification filter={filter} onUnreadCountChange={setUnreadCount} />
+      {sheetOpen && <NotificationSettingsSheet onClose={() => setSheetOpen(false)} />}
+    </>
+  )
+}

--- a/src/pages/NotificationPage.tsx
+++ b/src/pages/NotificationPage.tsx
@@ -17,13 +17,12 @@ export default function NotificationPage() {
   return (
     <>
       <Header
-        unreadCount={unreadCount}
+        title="알림"
         subLeft={
           <button className={styles.iconBtn} aria-label="뒤로가기" onClick={() => navigate(-1)}>
             <IoChevronBack size={20} />
           </button>
         }
-        subTitle="알림"
         subRight={
           <button className={styles.iconBtn} aria-label="설정" onClick={() => setSheetOpen(true)}>
             <IoSettingsOutline size={20} />

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,5 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom'
 import HomePage from '@/pages/HomePage'
+import NotificationPage from '@/pages/NotificationPage'
 import RecordMainPage from '@/features/record/pages/RecordMainPage'
 import RecordDetailPage from '@/features/record/pages/RecordDetailPage'
 import RecordInterventionPage from '@/features/intervention/pages/RecordInterventionPage'
@@ -11,7 +12,8 @@ const router = createBrowserRouter([
   { path: '/', element: <HomePage /> },
   { path: '/login', element: <LoginPage /> },
   { path: '/signup', element: <SignUpPage /> },
-  { path: '/mypage', element: <MyPagePage /> }, 
+  { path: '/mypage', element: <MyPagePage /> },
+  { path: '/notification', element: <NotificationPage /> },
 
   // TODO: 랜딩, 로그인, 유혹관리, 마이페이지 라우트 추가
   { path: '/record', element: <RecordMainPage /> },


### PR DESCRIPTION
## 📌 작업 내용

- 상단 헤더 레이아웃 구현 (뒤로가기 버튼 / 알림 타이틀 / 설정 아이콘)
- 뒤로가기 버튼 클릭 시 이전 화면으로 이동 기능 구현
- 설정 아이콘 클릭 시 알림 설정 모달창 구현
- 필터 칩 UI 구현 (전체 보기 / 일반 알림 / 목표 현황 알림 / 재판단 알림)
- 필터 칩 선택 상태(선택/비선택) 스타일 구현

## 📷 스크린 샷

-
<img width="422" height="162" alt="image" src="https://github.com/user-attachments/assets/bbad283e-3bbe-4adc-967f-975febf6b0fd" />


## ⚠️ 참고 사항

-

## 🔗 관련 이슈

Closes #43 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 알림 페이지를 추가했습니다.
  * 전체, 일반, 목표현황, 재판단별 알림 필터 탭을 제공합니다.
  * 알림 설정을 열고 닫을 수 있습니다.
  * 읽지 않은 알림 수를 헤더에서 확인할 수 있습니다.
  * `/notification` 경로로 알림 페이지에 접근할 수 있습니다.

* **스타일**
  * 필터 탭, 로고 및 아이콘 버튼의 화면 스타일을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->