### PR TITLE
✨ [Feature] 소비 상세 페이지 구현

### DIFF
--- a/src/components/layout/Header.module.css
+++ b/src/components/layout/Header.module.css
@@ -43,7 +43,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 138px;
+  min-height: 138px;
   border-radius: 0 0 20px 20px;
   background: var(--Main-000, #f7fbfa);
   padding: 0 16px;

--- a/src/components/layout/Header.module.css
+++ b/src/components/layout/Header.module.css
@@ -9,19 +9,19 @@
   grid-template-columns: auto 1fr auto;
   width: 100%;
   height: 50px;
-  background: var(--Main-000, #F7FBFA);
+  background: var(--Main-000, #f7fbfa);
   padding: 0 16px;
   align-items: center;
   box-sizing: border-box;
 }
-  
+
 .left {
   display: flex;
   height: 100%;
   justify-content: flex-start;
   align-items: center;
 }
-  
+
 .right {
   display: flex;
   height: 100%;
@@ -29,10 +29,10 @@
   align-items: center;
   justify-content: flex-end;
 }
-  
+
 .title {
   color: var(--Primary, #243130);
-  text-align: center;  
+  text-align: center;
   font-size: 18px;
   font-weight: 600;
   line-height: 1;
@@ -45,7 +45,7 @@
   width: 100%;
   height: 138px;
   border-radius: 0 0 20px 20px;
-  background: var(--Main-000, #F7FBFA);
+  background: var(--Main-000, #f7fbfa);
   padding: 0 16px;
   gap: 16px;
   box-sizing: border-box;
@@ -71,6 +71,15 @@
   justify-content: flex-end;
 }
 
+.subTitle {
+  color: var(--Primary, #243130);
+  text-align: center;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 1;
+  margin: 0;
+}
+
 .right button,
 .subLeft button,
 .subRight button {
@@ -80,7 +89,7 @@
 .right button:hover,
 .subLeft button:hover,
 .subRight button:hover {
-  color: var(--Gray-300, #5B6B6A);
+  color: var(--Gray-300, #5b6b6a);
 }
 
 .subMain {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,13 +1,14 @@
-import styles from "./Header.module.css";
+import styles from './Header.module.css'
 
 interface HeaderProps {
-  title?: string;
-  left?: React.ReactNode;
-  right?: React.ReactNode;
+  title?: string
+  left?: React.ReactNode
+  right?: React.ReactNode
 
-  subLeft?: React.ReactNode;
-  subRight?: React.ReactNode;
-  subMain?: React.ReactNode;
+  subLeft?: React.ReactNode
+  subRight?: React.ReactNode
+  subTitle?: React.ReactNode
+  subMain?: React.ReactNode
 }
 
 export default function Header({
@@ -16,46 +17,36 @@ export default function Header({
   right,
   subLeft,
   subRight,
-  subMain
+  subTitle,
+  subMain,
 }: HeaderProps) {
-  const hasSubContent = Boolean(subLeft || subRight || subMain);
-    
+  const hasSubContent = Boolean(subLeft || subRight || subTitle || subMain)
+
   return (
     <header className={styles.header}>
-        {/* topBar: 최상단 헤더(Logo, 알림 아이콘, 햄버거 메뉴 등) */}
-        <div className={styles.topBar}>
-            <div className={styles.left}>
-                {left}
-            </div>
+      {/* topBar: 최상단 헤더(Logo, 알림 아이콘, 햄버거 메뉴 등) */}
+      <div className={styles.topBar}>
+        <div className={styles.left}>{left}</div>
 
-            {title && <h1 className={styles.title}>
-                {title}
-            </h1>}
+        {title && <h1 className={styles.title}>{title}</h1>}
 
-            <div className={styles.right}>
-                {right}
-            </div>
-        </div>  
-      
-        {/* subContent: 하위 헤더(뒤로가기 아이콘, 페이지별 내용 등) */}
-        { hasSubContent && (
-           <div className={styles.subContent}>
-                <div className={styles.subTop}>
-                    <div className={styles.subLeft}>
-                        {subLeft}
-                    </div>
-                    <div />
-                    {/* subRight: 필요할 경우 넣을 우측 요소 */}
-                    <div className={styles.subRight}>
-                        {subRight}
-                    </div>
-                </div>
-                
-                <div className={styles.subMain}>
-                    {subMain}
-                </div>
-            </div> 
-        )}
+        <div className={styles.right}>{right}</div>
+      </div>
+
+      {/* subContent: 하위 헤더(뒤로가기 아이콘, 페이지별 내용 등) */}
+      {hasSubContent && (
+        <div className={styles.subContent}>
+          <div className={styles.subTop}>
+            <div className={styles.subLeft}>{subLeft}</div>
+            {subTitle && <h2 className={styles.subTitle}>{subTitle}</h2>}
+            {!subTitle && <div />}
+            {/* subRight: 필요할 경우 넣을 우측 요소 */}
+            <div className={styles.subRight}>{subRight}</div>
+          </div>
+
+          <div className={styles.subMain}>{subMain}</div>
+        </div>
+      )}
     </header>
-  );
+  )
 }

--- a/src/features/record/components/RecordCard/RecordCard.tsx
+++ b/src/features/record/components/RecordCard/RecordCard.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom'
+import type { RecordType } from '@/features/record/mockRecords'
 import styles from './RecordCard.module.css'
-
-export type RecordType = 'saved' | 'consume'
 
 interface RecordCardProps {
   id: string

--- a/src/features/record/components/RecordCard/index.ts
+++ b/src/features/record/components/RecordCard/index.ts
@@ -1,2 +1,2 @@
 export { default } from './RecordCard'
-export type { RecordType } from './RecordCard'
+export type { RecordType } from '@/features/record/mockRecords'

--- a/src/features/record/components/RecordList/RecordList.tsx
+++ b/src/features/record/components/RecordList/RecordList.tsx
@@ -1,87 +1,38 @@
 import styles from './RecordList.module.css'
 import DateSection from '../DateSection'
 import RecordCard from '../RecordCard'
-import type { RecordType } from '../RecordCard'
+import { MOCK_RECORDS } from '@/features/record/mockRecords'
+import type { RecordType } from '@/features/record/mockRecords'
 
 export type FilterValue = 'all' | RecordType
-
-interface RecordItem {
-  id: string
-  title: string
-  category: string
-  amount: number
-  type: RecordType
-  thumbnail?: string
-}
-
-interface RecordGroup {
-  date: string
-  records: RecordItem[]
-}
-
-// 하드코딩됨. API 연결 시 수정 예정
-const mockData: RecordGroup[] = [
-  {
-    date: '2026년 4월 17일',
-    records: [
-      {
-        id: '1',
-        title: '투썸플레이스 신봉점',
-        category: '카페/디저트',
-        amount: 6100,
-        type: 'saved',
-      },
-      {
-        id: '2',
-        title: 'ZARA 반팔티',
-        category: '의류',
-        amount: 23900,
-        type: 'consume',
-      },
-    ],
-  },
-  {
-    date: '2026년 4월 14일',
-    records: [
-      {
-        id: '3',
-        title: '무신사',
-        category: '패션',
-        amount: 35000,
-        type: 'saved',
-      },
-    ],
-  },
-]
 
 interface RecordListProps {
   filter: FilterValue
 }
 
 export default function RecordList({ filter }: RecordListProps) {
-  const filteredData = mockData
-    .map((group) => ({
-      ...group,
-      records:
-        filter === 'all' ? group.records : group.records.filter((record) => record.type === filter),
-    }))
-    .filter((group) => group.records.length > 0)
+  const filtered =
+    filter === 'all' ? MOCK_RECORDS : MOCK_RECORDS.filter((record) => record.type === filter)
+
+  const dates = Array.from(new Set(filtered.map((record) => record.date)))
 
   return (
     <div className={styles.container}>
-      {filteredData.map((group) => (
-        <DateSection key={group.date} date={group.date}>
-          {group.records.map((record) => (
-            <RecordCard
-              key={record.id}
-              id={record.id}
-              title={record.title}
-              category={record.category}
-              amount={record.amount}
-              type={record.type}
-              thumbnail={record.thumbnail}
-            />
-          ))}
+      {dates.map((date) => (
+        <DateSection key={date} date={date}>
+          {filtered
+            .filter((record) => record.date === date)
+            .map((record) => (
+              <RecordCard
+                key={record.id}
+                id={record.id}
+                title={record.title}
+                category={record.category}
+                amount={record.amount}
+                type={record.type}
+                thumbnail={record.thumbnail}
+              />
+            ))}
         </DateSection>
       ))}
     </div>

--- a/src/features/record/mockRecords.ts
+++ b/src/features/record/mockRecords.ts
@@ -1,0 +1,43 @@
+export type RecordType = 'saved' | 'consume'
+
+export interface RecordItem {
+  id: string
+  title: string
+  category: string
+  amount: number
+  type: RecordType
+  date: string
+  reason?: string
+  thumbnail?: string
+}
+
+// 하드코딩됨. API 연결 시 수정 예정
+export const MOCK_RECORDS: RecordItem[] = [
+  {
+    id: '1',
+    title: '투썸플레이스 신봉점',
+    category: '카페/디저트',
+    amount: 6100,
+    type: 'saved',
+    date: '2026년 4월 17일',
+    reason: '스트레스 받아서',
+  },
+  {
+    id: '2',
+    title: 'ZARA 반팔티',
+    category: '패션',
+    amount: 23900,
+    type: 'consume',
+    date: '2026년 4월 17일',
+    reason: '계절이 바뀌어서',
+  },
+  {
+    id: '3',
+    title: '무신사',
+    category: '패션',
+    amount: 35000,
+    type: 'saved',
+    date: '2026년 4월 14일',
+    reason: '세일해서',
+  },
+]

--- a/src/features/record/pages/RecordDetailPage.module.css
+++ b/src/features/record/pages/RecordDetailPage.module.css
@@ -1,7 +1,9 @@
 .summary {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
+  margin-top: 19px;
+  padding-bottom: 40px;
 }
 
 .title {
@@ -32,14 +34,25 @@
 .content {
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  padding: 24px 37px 32px;
+  padding: 27px 37px 32px;
 }
 
 .section {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+}
+
+.categorySection {
+  margin-bottom: 24px;
+}
+
+.categorySection .sectionLabel {
+  margin-bottom: 8px;
+}
+
+.reasonSection .sectionLabel {
+  margin-bottom: 16px;
+  font-size: 12px;
 }
 
 .sectionLabel {
@@ -71,6 +84,8 @@
   color: var(--color-main-500, #2f7f82);
   background: var(--color-text-white, #fefefe);
   white-space: nowrap;
+  cursor: pointer;
+  transition: 0.2s ease;
 }
 
 .chipSelected {
@@ -79,10 +94,13 @@
 }
 
 .reason {
-  margin: 0;
-  padding-bottom: 16px;
+  margin: 0 0 16px;
+  padding-bottom: 7px;
   border-bottom: 1px solid var(--color-gray-100, #dddddd);
-  font-size: 16px;
+  font-family: Pretendard;
+  font-size: 14px;
+  font-style: normal;
   font-weight: 600;
+  line-height: normal;
   color: var(--color-text-primary, #243130);
 }

--- a/src/features/record/pages/RecordDetailPage.module.css
+++ b/src/features/record/pages/RecordDetailPage.module.css
@@ -1,0 +1,88 @@
+.summary {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.title {
+  margin: 0;
+  font-family: Pretendard;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  color: var(--color-gray-300, #5b6b6a);
+}
+
+.amount {
+  margin: 0;
+  font-family: Pretendard;
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: normal;
+  color: var(--color-text-primary, #243130);
+}
+
+.amount.consume {
+  color: var(--color-gray-300, #5b6b6a);
+  text-decoration: line-through;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  padding: 24px 37px 32px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.sectionLabel {
+  margin: 0;
+  font-family: Pretendard;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  color: var(--color-gray-300, #5b6b6a);
+}
+
+.chipGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px;
+  padding: 0 8px;
+  border-radius: 14px;
+  border: 1.5px solid var(--color-main-500, #2f7f82);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-main-500, #2f7f82);
+  background: var(--color-text-white, #fefefe);
+  white-space: nowrap;
+}
+
+.chipSelected {
+  color: var(--color-text-white, #fefefe);
+  background: var(--color-main-500, #2f7f82);
+}
+
+.reason {
+  margin: 0;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--color-gray-100, #dddddd);
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--color-text-primary, #243130);
+}

--- a/src/features/record/pages/RecordDetailPage.module.css
+++ b/src/features/record/pages/RecordDetailPage.module.css
@@ -78,7 +78,7 @@
   height: 28px;
   padding: 0 8px;
   border-radius: 14px;
-  border: 1.5px solid var(--color-main-500, #2f7f82);
+  border: 1px solid var(--color-main-500, #2f7f82);
   font-size: 12px;
   font-weight: 500;
   color: var(--color-main-500, #2f7f82);

--- a/src/features/record/pages/RecordDetailPage.module.css
+++ b/src/features/record/pages/RecordDetailPage.module.css
@@ -79,6 +79,7 @@
   padding: 0 8px;
   border-radius: 14px;
   border: 1px solid var(--color-main-500, #2f7f82);
+  font-family: Pretendard;
   font-size: 12px;
   font-weight: 500;
   color: var(--color-main-500, #2f7f82);

--- a/src/features/record/pages/RecordDetailPage.tsx
+++ b/src/features/record/pages/RecordDetailPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { IoChevronBack, IoNotifications, IoPencilOutline } from 'react-icons/io5'
 import { PiListBold } from 'react-icons/pi'
@@ -52,6 +53,7 @@ export default function RecordDetailPage() {
   const navigate = useNavigate()
 
   const record = (id && MOCK_RECORDS[id]) || MOCK_RECORDS['1']
+  const [selectedCategory, setSelectedCategory] = useState(record.category)
 
   return (
     <div>
@@ -93,21 +95,23 @@ export default function RecordDetailPage() {
       />
 
       <div className={styles.content}>
-        <section className={styles.section}>
+        <section className={`${styles.section} ${styles.categorySection}`}>
           <h2 className={styles.sectionLabel}>카테고리</h2>
           <div className={styles.chipGroup}>
             {CATEGORIES.map((category) => (
-              <span
+              <button
                 key={category}
-                className={`${styles.chip} ${category === record.category ? styles.chipSelected : ''}`}
+                type="button"
+                className={`${styles.chip} ${category === selectedCategory ? styles.chipSelected : ''}`}
+                onClick={() => setSelectedCategory(category)}
               >
                 {category}
-              </span>
+              </button>
             ))}
           </div>
         </section>
 
-        <section className={styles.section}>
+        <section className={`${styles.section} ${styles.reasonSection}`}>
           <h2 className={styles.sectionLabel}>사고 싶은 이유</h2>
           <p className={styles.reason}>{record.reason}</p>
         </section>

--- a/src/features/record/pages/RecordDetailPage.tsx
+++ b/src/features/record/pages/RecordDetailPage.tsx
@@ -1,14 +1,119 @@
-import { useParams } from 'react-router-dom'
-import Header from '@/components/Header'
+import { useParams, useNavigate } from 'react-router-dom'
+import { IoChevronBack, IoNotifications, IoPencilOutline } from 'react-icons/io5'
+import { PiListBold } from 'react-icons/pi'
+import Header from '@/components/layout/Header'
+import RecentSpendingList from '@/features/intervention/components/RecentSpendingList'
+import type { RecentSpendingItem } from '@/features/intervention/components/RecentSpendingList'
+import { CATEGORIES } from '@/constants/product'
+import styles from './RecordDetailPage.module.css'
+
+interface RecordDetail {
+  title: string
+  amount: number
+  category: string
+  reason: string
+  type: 'saved' | 'consume'
+}
+
+// 하드코딩됨. API 연결 시 id로 실제 데이터 조회하도록 수정 예정
+const MOCK_RECORDS: Record<string, RecordDetail> = {
+  '1': {
+    title: '투썸플레이스 신봉점',
+    amount: 6100,
+    category: '카페/디저트',
+    reason: '스트레스 받아서',
+    type: 'saved',
+  },
+  '2': {
+    title: 'ZARA 반팔티',
+    amount: 23900,
+    category: '패션',
+    reason: '계절이 바뀌어서',
+    type: 'consume',
+  },
+  '3': {
+    title: '무신사',
+    amount: 35000,
+    category: '패션',
+    reason: '세일해서',
+    type: 'saved',
+  },
+}
+
+// 하드코딩됨. API 연결 시 수정 예정
+const RECENT_RECORDS: RecentSpendingItem[] = [
+  { id: '1', title: '투썸플레이스 신봉점', date: '4월 16일', amount: 6100 },
+  { id: '2', title: '투썸플레이스 신봉점', date: '4월 16일', amount: 6100 },
+  { id: '3', title: '투썸플레이스 신봉점', date: '4월 16일', amount: 6100 },
+]
 
 export default function RecordDetailPage() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
 
-  // 하드코딩됨. API 연결 시 id로 상세 데이터 조회하도록 수정 예정
+  const record = (id && MOCK_RECORDS[id]) || MOCK_RECORDS['1']
+
   return (
     <div>
-      <Header title="소비 상세" />
-      <p>id: {id}</p>
+      <Header
+        left={
+          <button type="button" aria-label="로고">
+            Logo
+          </button>
+        }
+        right={
+          <>
+            <button type="button" aria-label="알림">
+              <IoNotifications />
+            </button>
+            <button type="button" aria-label="메뉴 열기">
+              <PiListBold />
+            </button>
+          </>
+        }
+        subLeft={
+          <button type="button" aria-label="뒤로 가기" onClick={() => navigate(-1)}>
+            <IoChevronBack size={20} />
+          </button>
+        }
+        subTitle="소비 상세"
+        subRight={
+          <button type="button" aria-label="수정">
+            <IoPencilOutline size={20} />
+          </button>
+        }
+        subMain={
+          <div className={styles.summary}>
+            <p className={styles.title}>{record.title}</p>
+            <p className={`${styles.amount} ${record.type === 'consume' ? styles.consume : ''}`}>
+              {record.type === 'saved' ? '+' : '-'} {record.amount.toLocaleString('ko-KR')} 원
+            </p>
+          </div>
+        }
+      />
+
+      <div className={styles.content}>
+        <section className={styles.section}>
+          <h2 className={styles.sectionLabel}>카테고리</h2>
+          <div className={styles.chipGroup}>
+            {CATEGORIES.map((category) => (
+              <span
+                key={category}
+                className={`${styles.chip} ${category === record.category ? styles.chipSelected : ''}`}
+              >
+                {category}
+              </span>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.section}>
+          <h2 className={styles.sectionLabel}>사고 싶은 이유</h2>
+          <p className={styles.reason}>{record.reason}</p>
+        </section>
+
+        <RecentSpendingList count={RECENT_RECORDS.length} records={RECENT_RECORDS} />
+      </div>
     </div>
   )
 }

--- a/src/features/record/pages/RecordDetailPage.tsx
+++ b/src/features/record/pages/RecordDetailPage.tsx
@@ -1,62 +1,35 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { IoChevronBack, IoNotifications, IoPencilOutline } from 'react-icons/io5'
 import { PiListBold } from 'react-icons/pi'
 import Header from '@/components/layout/Header'
 import RecentSpendingList from '@/features/intervention/components/RecentSpendingList'
-import type { RecentSpendingItem } from '@/features/intervention/components/RecentSpendingList'
+import { MOCK_RECORDS } from '@/features/record/mockRecords'
 import { CATEGORIES } from '@/constants/product'
 import styles from './RecordDetailPage.module.css'
-
-interface RecordDetail {
-  title: string
-  amount: number
-  category: string
-  reason: string
-  type: 'saved' | 'consume'
-}
-
-// 하드코딩됨. API 연결 시 id로 실제 데이터 조회하도록 수정 예정
-const MOCK_RECORDS: Record<string, RecordDetail> = {
-  '1': {
-    title: '투썸플레이스 신봉점',
-    amount: 6100,
-    category: '카페/디저트',
-    reason: '스트레스 받아서',
-    type: 'saved',
-  },
-  '2': {
-    title: 'ZARA 반팔티',
-    amount: 23900,
-    category: '패션',
-    reason: '계절이 바뀌어서',
-    type: 'consume',
-  },
-  '3': {
-    title: '무신사',
-    amount: 35000,
-    category: '패션',
-    reason: '세일해서',
-    type: 'saved',
-  },
-}
-
-// 하드코딩됨. API 연결 시 수정 예정
-const RECENT_RECORDS: RecentSpendingItem[] = [
-  { id: '1', title: '투썸플레이스 신봉점', date: '4월 16일', amount: 6100 },
-  { id: '2', title: '투썸플레이스 신봉점', date: '4월 16일', amount: 6100 },
-  { id: '3', title: '투썸플레이스 신봉점', date: '4월 16일', amount: 6100 },
-]
 
 export default function RecordDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
 
-  const record = (id && MOCK_RECORDS[id]) || MOCK_RECORDS['1']
-  const [selectedCategory, setSelectedCategory] = useState(record.category)
+  const record = MOCK_RECORDS.find((item) => item.id === id)
+
+  useEffect(() => {
+    if (!record) {
+      navigate('/record', { replace: true })
+    }
+  }, [record, navigate])
+
+  const [selectedCategory, setSelectedCategory] = useState(record?.category)
+
+  if (!record) return null
+
+  const recentRecords = MOCK_RECORDS.filter(
+    (item) => item.category === selectedCategory && item.id !== record.id,
+  )
 
   return (
-    <div>
+    <div key={record.id}>
       <Header
         left={
           <button type="button" aria-label="로고">
@@ -111,12 +84,22 @@ export default function RecordDetailPage() {
           </div>
         </section>
 
-        <section className={`${styles.section} ${styles.reasonSection}`}>
-          <h2 className={styles.sectionLabel}>사고 싶은 이유</h2>
-          <p className={styles.reason}>{record.reason}</p>
-        </section>
+        {record.reason && (
+          <section className={`${styles.section} ${styles.reasonSection}`}>
+            <h2 className={styles.sectionLabel}>사고 싶은 이유</h2>
+            <p className={styles.reason}>{record.reason}</p>
+          </section>
+        )}
 
-        <RecentSpendingList count={RECENT_RECORDS.length} records={RECENT_RECORDS} />
+        <RecentSpendingList
+          count={recentRecords.length}
+          records={recentRecords.map((item) => ({
+            id: item.id,
+            title: item.title,
+            date: item.date,
+            amount: item.amount,
+          }))}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## 📌 작업 내용

- 공용 `Header`(`@/components/layout/Header`)에 `subTitle` prop 추가 (뒤로가기 + 제목 + 수정 아이콘이 한 줄에 오도록)
- `RecordDetailPage` 구현: 소비 요약(가게명/금액), 카테고리 칩, 사고 싶은 이유, 최근 해당 카테고리 소비 리스트(`RecentSpendingList` 재사용)
- 간격/타이포를 Figma 스펙에 맞춰 세부 조정 (섹션 간 간격, 라벨/텍스트 폰트 크기 등)
- 카테고리 칩을 클릭 가능한 버튼으로 구현, 클릭 시 선택 색상 토글
- 공용 `Header`의 `subContent` 높이를 고정값(138px) → `min-height`로 변경 (콘텐츠가 길어져도 안 잘리도록)

</br>

## 📷 스크린 샷
<img width="600" alt="image" src="https://github.com/user-attachments/assets/9ff09f25-2394-45dd-a92d-e9b2d011cd1a" />

</br>

## ⚠️ 참고 사항
- 소비 상세 데이터는 id 기준 하드코딩된 목데이터입니다. API 연결 시 실제 조회 로직으로 교체 예정입니다
- 카테고리 칩은 현재 로컬 상태로 선택만 토글되며, 실제 저장(수정) 로직은 연결되어 있지 않습니다 (우측 상단 수정 아이콘 클릭 동작도 아직 미구현)

</br>

## 🔗 관련 이슈

Closes #56 
</br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 소비 상세 화면을 라우트 ID로 조회해 상세 정보(금액 요약/카테고리/사유, 사유가 있을 때)와 동일 카테고리의 최근 지출을 표시합니다.
  - 카테고리 선택 칩으로 필터/표시 상태를 전환할 수 있습니다.
- **스타일 개선**
  - 소비 상세 페이지의 레이아웃과 칩/상태(취소선 포함) 디자인을 추가했습니다.
  - 헤더 하단 영역은 최소 높이로 조정하고, 버튼/배지 색상 폴백 표기를 정리했습니다.
- **리팩터링**
  - 레코드 목록은 목 데이터 기반으로 날짜 섹션을 구성하도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->