### PR TITLE
✨ [Feature] Screen Specification 반영 - 홈 페이지 수정 사항

### DIFF
--- a/src/features/home/Home.module.css
+++ b/src/features/home/Home.module.css
@@ -9,3 +9,30 @@
   gap: 20px;
   padding: 0 20px 32px;
 }
+
+.errorState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 20px;
+  gap: 16px;
+}
+
+.errorText {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-gray-200);
+  text-align: center;
+}
+
+.retryButton {
+  padding: 10px 24px;
+  background: var(--color-main-300);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/src/features/home/api/homeApi.ts
+++ b/src/features/home/api/homeApi.ts
@@ -1,0 +1,72 @@
+// import client from '@/api/client'
+import type { HomeData, CategoryData } from '../types'
+
+const BAR_COLORS = ['#286A6D', '#C7E3E3', '#E5F2F1', '#2F7F82', '#286A6D']
+
+// ─── Mock 데이터 (API 연결 후 제거) ────────────────────────────────────────
+interface SpendingRecord {
+  category: string
+  amount: number
+  type: 'bought' | 'resisted'
+}
+
+const mockRecords: SpendingRecord[] = [
+  { category: '음식', amount: 150000, type: 'bought' },
+  { category: '취미/굿즈', amount: 80000, type: 'bought' },
+  { category: '패션', amount: 120000, type: 'bought' },
+  { category: '여행', amount: 60000, type: 'bought' },
+  { category: '뷰티', amount: 30000, type: 'bought' },
+  { category: '음식', amount: 30000, type: 'resisted' },
+  { category: '전자기기', amount: 200000, type: 'resisted' },
+  { category: '패션', amount: 120000, type: 'resisted' },
+]
+
+function buildHomeData(): HomeData {
+  const bought = mockRecords.filter((r) => r.type === 'bought')
+  const resisted = mockRecords.filter((r) => r.type === 'resisted')
+
+  const categoryMap = new Map<string, number>()
+  for (const r of bought) {
+    categoryMap.set(r.category, (categoryMap.get(r.category) ?? 0) + r.amount)
+  }
+
+  const sorted = [...categoryMap.entries()].sort((a, b) => b[1] - a[1])
+  const top4 = sorted.slice(0, 4)
+  const rest = sorted.slice(4)
+  const otherAmount = rest.reduce((sum, [, amount]) => sum + amount, 0)
+
+  const categories: CategoryData[] = [
+    ...top4.map(([label, amount], i) => ({
+      label,
+      amount,
+      color: BAR_COLORS[i],
+      isOther: false,
+    })),
+    ...(otherAmount > 0
+      ? [{ label: '그 외', amount: otherAmount, color: BAR_COLORS[4], isOther: true }]
+      : []),
+  ]
+
+  const monthlySpending = bought.reduce((sum, r) => sum + r.amount, 0)
+  const goalCurrent = resisted.reduce((sum, r) => sum + r.amount, 0)
+
+  return {
+    monthlySpending,
+    lastMonthSpending: 320000,
+    budget: 500000,
+    goalAmount: 500000,
+    goalCurrent,
+    categories,
+    hasRecords: bought.length > 0,
+  }
+}
+// ──────────────────────────────────────────────────────────────────────────
+
+export const homeApi = {
+  getHomeData: async (): Promise<HomeData> => {
+    // TODO: API 연결 시 아래 두 줄로 교체하고 mock 제거
+    // const { data } = await client.get<HomeData>('/home')
+    // return data
+    return buildHomeData()
+  },
+}

--- a/src/features/home/components/CategoryChart.module.css
+++ b/src/features/home/components/CategoryChart.module.css
@@ -1,27 +1,28 @@
 .card {
   background: var(--color-text-white);
   border-radius: 16px;
-  padding: 16px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  padding: 17px;
+  border: 1px solid #f3f4f6;
+  box-shadow: 0 1px 1.5px 0 rgba(0, 0, 0, 0.1), 0 1px 1px 0 rgba(0, 0, 0, 0.1);
 }
 
 .header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 24px;
+  margin-bottom: 12px;
 }
 
 .title {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
+  font-size: 13px;
+  font-weight: 700;
   color: var(--color-text-primary);
 }
 
 .detailButton {
   font-size: 12px;
-  color: var(--color-gray-200);
+  font-weight: 500;
+  color: var(--color-main-500);
   background: none;
   border: none;
   cursor: pointer;
@@ -44,10 +45,11 @@
   align-items: center;
   gap: 4px;
   flex: 1;
+  cursor: pointer;
 }
 
 .bar {
-  width: 100%;
+  width: 38px;
   border-radius: 4px 4px 0 0;
 }
 
@@ -58,13 +60,37 @@
 }
 
 .message {
-  margin: 12px 0 0;
-  font-size: 12px;
+  margin: 8px 0 0;
+  font-size: 11px;
   color: var(--color-gray-300);
-  line-height: 1.6;
+  text-align: center;
+  line-height: 1.5;
 }
 
 .messageBold {
-  font-weight: 700;
-  color: var(--color-text-primary);
+  font-weight: 600;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 24px 0 8px;
+}
+
+.emptyText {
+  margin: 0;
+  font-size: 13px;
+  color: var(--color-gray-300);
+}
+
+.recordButton {
+  padding: 8px 20px;
+  background: var(--color-main-300);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  cursor: pointer;
 }

--- a/src/features/home/components/CategoryChart.tsx
+++ b/src/features/home/components/CategoryChart.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom'
+import { formatKRW } from '@/shared/utils/currency'
 import type { CategoryData } from '../types'
 import styles from './CategoryChart.module.css'
 
@@ -49,7 +50,7 @@ export default function CategoryChart({ categories, hasRecords, topCategoryLabel
                     height: `${(cat.amount / maxAmount) * MAX_BAR_HEIGHT}px`,
                     backgroundColor: cat.color,
                   }}
-                  aria-label={`${cat.label} ${cat.amount.toLocaleString('ko-KR')}원`}
+                  aria-label={`${cat.label} ${formatKRW(cat.amount)}`}
                 />
                 <span className={styles.barLabel}>{cat.label}</span>
               </div>

--- a/src/features/home/components/CategoryChart.tsx
+++ b/src/features/home/components/CategoryChart.tsx
@@ -1,49 +1,74 @@
+import { useNavigate } from 'react-router-dom'
+import type { CategoryData } from '../types'
 import styles from './CategoryChart.module.css'
 
-interface Category {
-  label: string
-  amount: number
-  color: string
-}
-
 interface CategoryChartProps {
-  categories: Category[]
+  categories: CategoryData[]
+  hasRecords: boolean
+  topCategoryLabel: string
 }
 
-const MAX_BAR_HEIGHT = 94
+const MAX_BAR_HEIGHT = 62
 
-export default function CategoryChart({ categories }: CategoryChartProps) {
-  const maxAmount = Math.max(...categories.map((c) => c.amount)) || 1
+export default function CategoryChart({ categories, hasRecords, topCategoryLabel }: CategoryChartProps) {
+  const navigate = useNavigate()
+  const maxAmount = Math.max(...categories.map((c) => c.amount), 1)
+  const totalAmount = categories.reduce((sum, c) => sum + c.amount, 0)
+  const topPercent = totalAmount > 0
+    ? Math.round((categories[0]?.amount ?? 0) / totalAmount * 100)
+    : 0
 
   return (
     <section className={styles.card}>
       <div className={styles.header}>
         <span className={styles.title}>카테고리별 지출</span>
-        {/* TODO: 상세 화면 연결 후 button으로 교체 */}
-        <span className={styles.detailButton}>상세 보기 &gt;</span>
+        <button className={styles.detailButton} onClick={() => navigate('/report')}>
+          상세 보기 &gt;
+        </button>
       </div>
 
-      <div className={styles.chartArea}>
-        {categories.map((cat) => (
-          <div key={cat.label} className={styles.barWrapper}>
-            <div
-              className={styles.bar}
-              style={{
-                height: `${(cat.amount / maxAmount) * MAX_BAR_HEIGHT}px`,
-                backgroundColor: cat.color,
-              }}
-              aria-label={`${cat.label} ${cat.amount.toLocaleString('ko-KR')}원`}
-              role="img"
-            />
-            <span className={styles.barLabel}>{cat.label}</span>
+      {hasRecords ? (
+        <>
+          <div className={styles.chartArea}>
+            {categories.map((cat) => (
+              <div
+                key={cat.label}
+                className={styles.barWrapper}
+                onClick={() =>
+                  cat.isOther
+                    ? navigate('/record?filter=other')
+                    : navigate(`/record?category=${encodeURIComponent(cat.label)}`)
+                }
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => e.key === 'Enter' && e.currentTarget.click()}
+              >
+                <div
+                  className={styles.bar}
+                  style={{
+                    height: `${(cat.amount / maxAmount) * MAX_BAR_HEIGHT}px`,
+                    backgroundColor: cat.color,
+                  }}
+                  aria-label={`${cat.label} ${cat.amount.toLocaleString('ko-KR')}원`}
+                />
+                <span className={styles.barLabel}>{cat.label}</span>
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
-
-      <p className={styles.message}>
-        이번 달은 절약이 목적이셨네요.{' '}
-        <strong className={styles.messageBold}>식비</strong> 지출이 조금 많았어요
-      </p>
+          <p className={styles.message}>
+            이번 달에는{' '}
+            <strong className={styles.messageBold}>{topCategoryLabel}</strong>
+            {' '}소비가 전체 지출의 {topPercent}%를 차지했어요.
+          </p>
+        </>
+      ) : (
+        <div className={styles.emptyState}>
+          <p className={styles.emptyText}>이번 달 소비 기록이 아직 없어요.</p>
+          <button className={styles.recordButton} onClick={() => navigate('/record')}>
+            소비 기록하기
+          </button>
+        </div>
+      )}
     </section>
   )
 }

--- a/src/features/home/components/EncouragementCard.module.css
+++ b/src/features/home/components/EncouragementCard.module.css
@@ -1,19 +1,20 @@
 .card {
   background: var(--color-text-white);
   border-radius: 16px;
-  padding: 16px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  padding: 17px;
+  border: 1px solid #f3f4f6;
+  box-shadow: 0 1px 1.5px 0 rgba(0, 0, 0, 0.1), 0 1px 1px 0 rgba(0, 0, 0, 0.1);
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
 }
 
 .iconWrapper {
   flex-shrink: 0;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
-  background-color: var(--color-main-100);
+  border-radius: 10px;
+  background-color: #e8f4f4;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -21,13 +22,14 @@
 
 .cardLabel {
   margin: 0;
-  font-size: 12px;
-  color: var(--color-gray-200);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-text-primary);
 }
 
 .cardText {
   margin: 2px 0 0;
-  font-size: 13px;
-  color: var(--color-text-primary);
-  line-height: 1.4;
+  font-size: 12px;
+  color: var(--color-gray-300);
+  line-height: 1.5;
 }

--- a/src/features/home/components/EncouragementCard.tsx
+++ b/src/features/home/components/EncouragementCard.tsx
@@ -1,10 +1,25 @@
 import styles from './EncouragementCard.module.css'
 
-interface EncouragementCardProps {
-  message: string
+const MESSAGES = [
+  '아직 시작 단계예요. 지금부터 조금씩 줄여볼까요?',
+  '작은 소비를 한 번 참는 것도 좋은 변화예요.',
+  '오늘도 목표를 향해 한 걸음 나아가고 있어요.',
+  '절약은 작은 습관에서 시작돼요. 오늘도 잘 하고 있어요!',
+  '지출을 돌아보는 것만으로도 충분히 잘 하고 있어요.',
+  '목표를 세운 것 자체가 이미 훌륭한 시작이에요.',
+  '오늘 하루도 현명한 소비를 위해 노력하고 있어요.',
+]
+
+function getDayIndex(length: number): number {
+  const now = new Date()
+  const start = new Date(now.getFullYear(), 0, 0)
+  const dayOfYear = Math.floor((now.getTime() - start.getTime()) / 86400000)
+  return dayOfYear % length
 }
 
-export default function EncouragementCard({ message }: EncouragementCardProps) {
+export default function EncouragementCard() {
+  const message = MESSAGES[getDayIndex(MESSAGES.length)]
+
   return (
     <div className={styles.card}>
       <div className={styles.iconWrapper}>

--- a/src/features/home/components/EncouragementCard.tsx
+++ b/src/features/home/components/EncouragementCard.tsx
@@ -1,3 +1,4 @@
+import { getDayIndex } from '@/shared/utils/date'
 import styles from './EncouragementCard.module.css'
 
 const MESSAGES = [
@@ -9,13 +10,6 @@ const MESSAGES = [
   '목표를 세운 것 자체가 이미 훌륭한 시작이에요.',
   '오늘 하루도 현명한 소비를 위해 노력하고 있어요.',
 ]
-
-function getDayIndex(length: number): number {
-  const now = new Date()
-  const start = new Date(now.getFullYear(), 0, 0)
-  const dayOfYear = Math.floor((now.getTime() - start.getTime()) / 86400000)
-  return dayOfYear % length
-}
 
 export default function EncouragementCard() {
   const message = MESSAGES[getDayIndex(MESSAGES.length)]

--- a/src/features/home/components/GoalProgress.module.css
+++ b/src/features/home/components/GoalProgress.module.css
@@ -1,54 +1,53 @@
-.section {
-  display: flex;
-  flex-direction: column;
-}
-
 .sectionLabel {
   margin: 0 0 8px;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-text-primary);
+  font-size: 12px;
+  color: var(--color-gray-300);
 }
 
 .card {
   background: white;
   border-radius: 16px;
-  padding: 16px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  padding: 17px;
+  border: 1px solid #f3f4f6;
+  box-shadow: 0 1px 1.5px 0 rgba(0, 0, 0, 0.1), 0 1px 1px 0 rgba(0, 0, 0, 0.1);
 }
 
 .cardHeader {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
 .cardTitle {
-  margin: 0;
   font-size: 13px;
+  font-weight: 700;
   color: var(--color-text-primary);
 }
 
 .badge {
   font-size: 11px;
-  font-weight: 600;
-  color: var(--color-text-green);
-  background-color: var(--color-main-100);
+  font-weight: 700;
+  color: var(--color-main-500);
+  background-color: #e8f4f4;
   padding: 2px 8px;
   border-radius: 999px;
 }
 
+.progressTrackWrap {
+  padding-top: 8px;
+}
+
 .progressTrack {
-  height: 16px;
-  background-color: #e0e0e0;
+  height: 12px;
+  background-color: #e0eeee;
   border-radius: 999px;
   overflow: hidden;
 }
 
 .progressBar {
   height: 100%;
-  background-color: var(--color-main-300);
+  background: linear-gradient(to right, var(--color-main-500), var(--color-main-400));
   border-radius: 999px;
   transition: width 0.5s ease;
 }
@@ -60,13 +59,18 @@
 }
 
 .amount {
-  margin: 0;
-  font-size: 12px;
+  font-size: 11px;
   color: var(--color-gray-300);
 }
 
 .remaining {
-  margin: 8px 0 0;
+  margin: 12px 0 0;
   font-size: 12px;
-  color: var(--color-gray-200);
+  color: var(--color-text-primary);
+  text-align: center;
+}
+
+.remainingAmount {
+  font-weight: 700;
+  color: var(--color-main-500);
 }

--- a/src/features/home/components/GoalProgress.tsx
+++ b/src/features/home/components/GoalProgress.tsx
@@ -1,12 +1,9 @@
+import { formatKRW } from '@/shared/utils/currency'
 import styles from './GoalProgress.module.css'
 
 interface GoalProgressProps {
   goalAmount: number | null
   goalCurrent: number
-}
-
-function formatKRW(amount: number) {
-  return amount.toLocaleString('ko-KR') + '원'
 }
 
 export default function GoalProgress({ goalAmount, goalCurrent }: GoalProgressProps) {

--- a/src/features/home/components/GoalProgress.tsx
+++ b/src/features/home/components/GoalProgress.tsx
@@ -1,26 +1,28 @@
 import styles from './GoalProgress.module.css'
 
 interface GoalProgressProps {
-  current: number
-  goal: number
+  goalAmount: number | null
+  goalCurrent: number
 }
 
 function formatKRW(amount: number) {
   return amount.toLocaleString('ko-KR') + '원'
 }
 
-export default function GoalProgress({ current, goal }: GoalProgressProps) {
-  const percent = Math.round((current / goal) * 100)
+export default function GoalProgress({ goalAmount, goalCurrent }: GoalProgressProps) {
+  const rawPercent = goalAmount ? Math.round((goalCurrent / goalAmount) * 100) : 0
+  const percent = Math.min(100, rawPercent)
+  const isAchieved = rawPercent >= 100
 
   return (
-    <section className={styles.section}>
+    <div className={styles.card}>
       <p className={styles.sectionLabel}>목표 달성률</p>
-      <div className={styles.card}>
-        <div className={styles.cardHeader}>
-          <span className={styles.cardTitle}>이번 달 절약 목표</span>
-          <span className={styles.badge}>{percent}% 달성</span>
-        </div>
+      <div className={styles.cardHeader}>
+        <span className={styles.cardTitle}>이번 달 절약 목표</span>
+        <span className={styles.badge}>{percent}% 달성</span>
+      </div>
 
+      <div className={styles.progressTrackWrap}>
         <div
           className={styles.progressTrack}
           role="progressbar"
@@ -28,21 +30,28 @@ export default function GoalProgress({ current, goal }: GoalProgressProps) {
           aria-valuemax={100}
           aria-valuenow={percent}
         >
-          <div
-            className={styles.progressBar}
-            style={{ width: `${percent}%` }}
-          />
+          <div className={styles.progressBar} style={{ width: `${percent}%` }} />
         </div>
-
-        <div className={styles.amounts}>
-          <span className={styles.amount}>{formatKRW(current)}</span>
-          <span className={styles.amount}>목표 {formatKRW(goal)}</span>
-        </div>
-
-        <p className={styles.remaining}>
-          목표까지 {formatKRW(goal - current)} 남았어요
-        </p>
       </div>
-    </section>
+
+      <div className={styles.amounts}>
+        <span className={styles.amount}>{formatKRW(goalCurrent)}</span>
+        <span className={styles.amount}>
+          {goalAmount ? `목표 ${formatKRW(goalAmount)}` : '목표 미설정'}
+        </span>
+      </div>
+
+      {goalAmount === null ? (
+        <p className={styles.remaining}>절약 목표를 설정해보세요.</p>
+      ) : isAchieved ? (
+        <p className={styles.remaining}>이번 달 절약 목표를 달성했어요!</p>
+      ) : (
+        <p className={styles.remaining}>
+          목표까지{' '}
+          <strong className={styles.remainingAmount}>{formatKRW(goalAmount - goalCurrent)}</strong>
+          {' '}남았어요
+        </p>
+      )}
+    </div>
   )
 }

--- a/src/features/home/components/HomeBanner.module.css
+++ b/src/features/home/components/HomeBanner.module.css
@@ -12,7 +12,7 @@
 
 .headerTitle {
   margin: 0;
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 700;
   color: var(--color-text-primary);
 }

--- a/src/features/home/components/HomeBanner.module.css
+++ b/src/features/home/components/HomeBanner.module.css
@@ -5,9 +5,9 @@
 
 .header {
   background-color: var(--color-main-000);
-  padding: 24px 0;
+  padding: 10px 0 26px;
   text-align: center;
-  border-bottom: 1px solid var(--color-main-100);
+  border-radius: 0 0 20px 20px;
 }
 
 .headerTitle {
@@ -20,12 +20,16 @@
 .headerSubtitle {
   margin: 4px 0 0;
   font-size: 13px;
-  color: var(--color-gray-300);
+  color: #898989;
 }
 
 .body {
   background-color: var(--color-text-white);
-  padding: 16px 20px 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+  padding: 16px 24px 20px 24px;
 }
 
 .date {
@@ -40,11 +44,4 @@
   font-weight: 700;
   color: var(--color-text-primary);
   line-height: 1.2;
-}
-
-.sectionLabel {
-  margin: 12px 0 0;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--color-text-primary);
 }

--- a/src/features/home/components/HomeBanner.tsx
+++ b/src/features/home/components/HomeBanner.tsx
@@ -2,11 +2,26 @@ import { getFormattedDateLabel } from '@/shared/utils/date'
 import styles from './HomeBanner.module.css'
 
 interface HomeBannerProps {
-  achievementPercent: number
+  goalSet: boolean
+  achievementPercent: number | null
 }
 
-export default function HomeBanner({ achievementPercent }: HomeBannerProps) {
+export default function HomeBanner({ goalSet, achievementPercent }: HomeBannerProps) {
   const dateLabel = getFormattedDateLabel()
+
+  let line1: string
+  let line2: string
+
+  if (!goalSet) {
+    line1 = '이번 달 절약 목표를'
+    line2 = '설정해보세요.'
+  } else if (achievementPercent !== null && achievementPercent >= 100) {
+    line1 = '이번 달 절약 목표를'
+    line2 = '달성했어요! 🎉'
+  } else {
+    line1 = `이번 달 목표 ${achievementPercent ?? 0}%`
+    line2 = '달성했어요 🎯'
+  }
 
   return (
     <section className={styles.section}>
@@ -18,9 +33,10 @@ export default function HomeBanner({ achievementPercent }: HomeBannerProps) {
       <div className={styles.body}>
         <p className={styles.date}>{dateLabel}</p>
         <p className={styles.achievement}>
-          이번 달 목표 {achievementPercent}%<br />달성했어요 🎯
+          {line1}
+          <br />
+          {line2}
         </p>
-        <p className={styles.sectionLabel}>이번 달 소비</p>
       </div>
     </section>
   )

--- a/src/features/home/components/HomeSkeleton.module.css
+++ b/src/features/home/components/HomeSkeleton.module.css
@@ -53,3 +53,12 @@
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .line,
+  .card,
+  .halfCard,
+  .smallCard {
+    animation: none;
+  }
+}

--- a/src/features/home/components/HomeSkeleton.module.css
+++ b/src/features/home/components/HomeSkeleton.module.css
@@ -1,0 +1,55 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 16px 20px 32px;
+}
+
+.banner {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 0;
+}
+
+.line {
+  height: 22px;
+  background: #e8e8e8;
+  border-radius: 4px;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.lineShort { width: 45%; }
+.lineLong { width: 65%; }
+
+.card {
+  height: 160px;
+  background: #e8e8e8;
+  border-radius: 16px;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+}
+
+.halfCard {
+  flex: 1;
+  height: 100px;
+  background: #e8e8e8;
+  border-radius: 16px;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+.smallCard {
+  height: 68px;
+  background: #e8e8e8;
+  border-radius: 16px;
+  animation: shimmer 1.5s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}

--- a/src/features/home/components/HomeSkeleton.tsx
+++ b/src/features/home/components/HomeSkeleton.tsx
@@ -2,19 +2,19 @@ import styles from './HomeSkeleton.module.css'
 
 export default function HomeSkeleton() {
   return (
-    <div className={styles.wrapper}>
-      <div className={styles.banner}>
+    <div className={styles.wrapper} role="status" aria-label="홈 정보 불러오는 중">
+      <div className={styles.banner} aria-hidden="true">
         <div className={`${styles.line} ${styles.lineShort}`} />
         <div className={`${styles.line} ${styles.lineLong}`} />
       </div>
-      <div className={styles.card} />
-      <div className={styles.row}>
+      <div className={styles.card} aria-hidden="true" />
+      <div className={styles.row} aria-hidden="true">
         <div className={styles.halfCard} />
         <div className={styles.halfCard} />
       </div>
-      <div className={styles.card} />
-      <div className={styles.smallCard} />
-      <div className={styles.smallCard} />
+      <div className={styles.card} aria-hidden="true" />
+      <div className={styles.smallCard} aria-hidden="true" />
+      <div className={styles.smallCard} aria-hidden="true" />
     </div>
   )
 }

--- a/src/features/home/components/HomeSkeleton.tsx
+++ b/src/features/home/components/HomeSkeleton.tsx
@@ -1,0 +1,20 @@
+import styles from './HomeSkeleton.module.css'
+
+export default function HomeSkeleton() {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.banner}>
+        <div className={`${styles.line} ${styles.lineShort}`} />
+        <div className={`${styles.line} ${styles.lineLong}`} />
+      </div>
+      <div className={styles.card} />
+      <div className={styles.row}>
+        <div className={styles.halfCard} />
+        <div className={styles.halfCard} />
+      </div>
+      <div className={styles.card} />
+      <div className={styles.smallCard} />
+      <div className={styles.smallCard} />
+    </div>
+  )
+}

--- a/src/features/home/components/SpendingQuestion.module.css
+++ b/src/features/home/components/SpendingQuestion.module.css
@@ -1,19 +1,20 @@
 .card {
   background: var(--color-text-white);
   border-radius: 16px;
-  padding: 16px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  padding: 17px;
+  border: 1px solid #f3f4f6;
+  box-shadow: 0 1px 1.5px 0 rgba(0, 0, 0, 0.1), 0 1px 1px 0 rgba(0, 0, 0, 0.1);
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 12px;
 }
 
 .iconWrapper {
   flex-shrink: 0;
   width: 40px;
   height: 40px;
-  border-radius: 50%;
-  background-color: var(--color-main-100);
+  border-radius: 10px;
+  background-color: #e8f4f4;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -21,13 +22,14 @@
 
 .cardLabel {
   margin: 0;
-  font-size: 12px;
-  color: var(--color-gray-200);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-text-primary);
 }
 
 .cardText {
   margin: 2px 0 0;
-  font-size: 13px;
-  color: var(--color-text-primary);
-  line-height: 1.4;
+  font-size: 12px;
+  color: var(--color-gray-300);
+  line-height: 1.5;
 }

--- a/src/features/home/components/SpendingQuestion.tsx
+++ b/src/features/home/components/SpendingQuestion.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom'
+import { getDayIndex } from '@/shared/utils/date'
 import styles from './SpendingQuestion.module.css'
 
 const QUESTIONS = [
@@ -11,13 +12,6 @@ const QUESTIONS = [
   '오늘 예산 내에서 소비했나요?',
 ]
 
-function getDayIndex(length: number): number {
-  const now = new Date()
-  const start = new Date(now.getFullYear(), 0, 0)
-  const dayOfYear = Math.floor((now.getTime() - start.getTime()) / 86400000)
-  return dayOfYear % length
-}
-
 export default function SpendingQuestion() {
   const navigate = useNavigate()
   const question = QUESTIONS[getDayIndex(QUESTIONS.length)]
@@ -28,7 +22,12 @@ export default function SpendingQuestion() {
       onClick={() => navigate('/record')}
       role="button"
       tabIndex={0}
-      onKeyDown={(e) => e.key === 'Enter' && navigate('/record')}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          navigate('/record')
+        }
+      }}
       style={{ cursor: 'pointer' }}
     >
       <div className={styles.iconWrapper}>

--- a/src/features/home/components/SpendingQuestion.tsx
+++ b/src/features/home/components/SpendingQuestion.tsx
@@ -1,12 +1,36 @@
+import { useNavigate } from 'react-router-dom'
 import styles from './SpendingQuestion.module.css'
 
-interface SpendingQuestionProps {
-  question: string
+const QUESTIONS = [
+  '오늘 계획하지 않은 소비가 있었나요?',
+  '오늘 꼭 필요하지 않은 물건을 사지는 않았나요?',
+  '오늘 참아낸 소비가 있었나요?',
+  '오늘 충동적으로 소비한 것이 있었나요?',
+  '오늘 소비를 줄일 수 있었던 순간이 있었나요?',
+  '오늘 지출 목록을 돌아보셨나요?',
+  '오늘 예산 내에서 소비했나요?',
+]
+
+function getDayIndex(length: number): number {
+  const now = new Date()
+  const start = new Date(now.getFullYear(), 0, 0)
+  const dayOfYear = Math.floor((now.getTime() - start.getTime()) / 86400000)
+  return dayOfYear % length
 }
 
-export default function SpendingQuestion({ question }: SpendingQuestionProps) {
+export default function SpendingQuestion() {
+  const navigate = useNavigate()
+  const question = QUESTIONS[getDayIndex(QUESTIONS.length)]
+
   return (
-    <div className={styles.card}>
+    <div
+      className={styles.card}
+      onClick={() => navigate('/record')}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => e.key === 'Enter' && navigate('/record')}
+      style={{ cursor: 'pointer' }}
+    >
       <div className={styles.iconWrapper}>
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
           <circle cx="12" cy="12" r="10" stroke="#389698" strokeWidth="1.8" />

--- a/src/features/home/components/SpendingSummary.module.css
+++ b/src/features/home/components/SpendingSummary.module.css
@@ -6,9 +6,10 @@
 .card {
   flex: 1;
   background: var(--color-text-white);
-  border-radius: 16px;
-  padding: 16px;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  border-radius: 14px;
+  padding: 15px 17px;
+  border: 1px solid #f3f4f6;
+  box-shadow: 0 1px 1.5px 0 rgba(0, 0, 0, 0.1), 0 1px 1px 0 rgba(0, 0, 0, 0.1);
 }
 
 .label {
@@ -17,22 +18,29 @@
   color: var(--color-text-primary);
 }
 
+.amountRow {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+}
+
 .amountRed {
-  margin: 4px 0 0;
-  font-size: 20px;
+  margin: 0;
+  font-size: 17px;
   font-weight: 700;
   color: var(--color-text-red);
 }
 
 .amountBlue {
-  margin: 4px 0 0;
-  font-size: 20px;
+  margin: 0;
+  font-size: 17px;
   font-weight: 700;
   color: var(--color-text-blue);
 }
 
 .sub {
-  margin: 4px 0 0;
+  margin: 6px 0 0;
   font-size: 11px;
-  color: var(--color-gray-200);
+  color: var(--color-gray-300);
 }

--- a/src/features/home/components/SpendingSummary.tsx
+++ b/src/features/home/components/SpendingSummary.tsx
@@ -79,10 +79,10 @@ export default function SpendingSummary({ monthlySpending, lastMonthSpending, bu
       {/* 남은 예산 */}
       <div
         className={styles.card}
-        onClick={isBudgetUnset ? () => navigate('/budget') : undefined}
+        onClick={isBudgetUnset ? () => navigate('/goal-amount') : undefined}
         role={isBudgetUnset ? 'button' : undefined}
         tabIndex={isBudgetUnset ? 0 : undefined}
-        onKeyDown={isBudgetUnset ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate('/budget') } } : undefined}
+        onKeyDown={isBudgetUnset ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate('/goal-amount') } } : undefined}
         style={isBudgetUnset ? { cursor: 'pointer' } : undefined}
       >
         <p className={styles.label}>남은 예산</p>

--- a/src/features/home/components/SpendingSummary.tsx
+++ b/src/features/home/components/SpendingSummary.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom'
+import { formatKRW } from '@/shared/utils/currency'
 import styles from './SpendingSummary.module.css'
 
 interface SpendingSummaryProps {
@@ -48,16 +49,17 @@ export default function SpendingSummary({ monthlySpending, lastMonthSpending, bu
   const remaining = budget !== null ? budget - monthlySpending : null
   const isOverBudget = remaining !== null && remaining < 0
 
-  let budgetAmount = ''
-  let budgetSub = ''
+  let budgetAmount: string
+  let budgetSub: string
 
   if (isBudgetUnset) {
+    budgetAmount = ''
     budgetSub = '이번 달 예산을 설정해주세요.'
   } else if (isOverBudget) {
-    budgetAmount = `${Math.abs(remaining!).toLocaleString()}원`
-    budgetSub = `예산을 ${Math.abs(remaining!).toLocaleString()}원 초과했어요`
+    budgetAmount = formatKRW(Math.abs(remaining!))
+    budgetSub = `예산을 ${formatKRW(Math.abs(remaining!))} 초과했어요`
   } else {
-    budgetAmount = `${remaining!.toLocaleString()}원`
+    budgetAmount = formatKRW(remaining!)
     budgetSub = '목표까지 남았어요'
   }
 
@@ -69,7 +71,7 @@ export default function SpendingSummary({ monthlySpending, lastMonthSpending, bu
         <div className={styles.amountRow}>
           {spendingTrend === 'up' && <UpArrowIcon color="#EB0000" />}
           {spendingTrend === 'down' && <DownArrowIcon color="#2946D8" />}
-          <p className={styles.amountRed}>{monthlySpending.toLocaleString()}원</p>
+          <p className={styles.amountRed}>{formatKRW(monthlySpending)}</p>
         </div>
         {comparisonLabel && <p className={styles.sub}>{comparisonLabel}</p>}
       </div>
@@ -79,6 +81,8 @@ export default function SpendingSummary({ monthlySpending, lastMonthSpending, bu
         className={styles.card}
         onClick={isBudgetUnset ? () => navigate('/budget') : undefined}
         role={isBudgetUnset ? 'button' : undefined}
+        tabIndex={isBudgetUnset ? 0 : undefined}
+        onKeyDown={isBudgetUnset ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate('/budget') } } : undefined}
         style={isBudgetUnset ? { cursor: 'pointer' } : undefined}
       >
         <p className={styles.label}>남은 예산</p>

--- a/src/features/home/components/SpendingSummary.tsx
+++ b/src/features/home/components/SpendingSummary.tsx
@@ -1,25 +1,99 @@
+import { useNavigate } from 'react-router-dom'
 import styles from './SpendingSummary.module.css'
 
 interface SpendingSummaryProps {
   monthlySpending: number
-  comparisonPercent: number
+  lastMonthSpending: number | null
+  budget: number | null
 }
 
-export default function SpendingSummary({ monthlySpending, comparisonPercent }: SpendingSummaryProps) {
-  const comparisonLabel = `${comparisonPercent > 0 ? '+' : ''}${comparisonPercent}%`
+function getComparisonLabel(monthlySpending: number, lastMonthSpending: number | null): string | null {
+  if (lastMonthSpending === null || lastMonthSpending === 0) return null
+  const percent = Math.round(((monthlySpending - lastMonthSpending) / lastMonthSpending) * 100)
+  if (percent === 0) return '지난달과 같아요'
+  return `지난 달보다 ${percent > 0 ? '+' : ''}${percent}%`
+}
+
+function getSpendingTrend(monthlySpending: number, lastMonthSpending: number | null): 'up' | 'down' | 'none' {
+  if (lastMonthSpending === null || lastMonthSpending === 0) return 'none'
+  if (monthlySpending > lastMonthSpending) return 'up'
+  if (monthlySpending < lastMonthSpending) return 'down'
+  return 'none'
+}
+
+function UpArrowIcon({ color }: { color: string }) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M12.8337 4.08334L7.87533 9.04168L4.95866 6.12501L1.16699 9.91668" stroke={color} strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M9.33301 4.08334H12.833V7.58334" stroke={color} strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function DownArrowIcon({ color }: { color: string }) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M12.8337 9.91668L7.87533 4.95834L4.95866 7.87501L1.16699 4.08334" stroke={color} strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M9.33301 9.91666H12.833V6.41666" stroke={color} strokeWidth="1.16667" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+export default function SpendingSummary({ monthlySpending, lastMonthSpending, budget }: SpendingSummaryProps) {
+  const navigate = useNavigate()
+  const comparisonLabel = getComparisonLabel(monthlySpending, lastMonthSpending)
+  const spendingTrend = getSpendingTrend(monthlySpending, lastMonthSpending)
+
+  const isBudgetUnset = budget === null
+  const remaining = budget !== null ? budget - monthlySpending : null
+  const isOverBudget = remaining !== null && remaining < 0
+
+  let budgetAmount = ''
+  let budgetSub = ''
+
+  if (isBudgetUnset) {
+    budgetSub = '이번 달 예산을 설정해주세요.'
+  } else if (isOverBudget) {
+    budgetAmount = `${Math.abs(remaining!).toLocaleString()}원`
+    budgetSub = `예산을 ${Math.abs(remaining!).toLocaleString()}원 초과했어요`
+  } else {
+    budgetAmount = `${remaining!.toLocaleString()}원`
+    budgetSub = '목표까지 남았어요'
+  }
 
   return (
     <div className={styles.wrapper}>
+      {/* 이번 달 지출 */}
       <div className={styles.card}>
         <p className={styles.label}>이번 달 지출</p>
-        <p className={styles.amountRed}>{monthlySpending.toLocaleString()}원</p>
-        <p className={styles.sub}>지난 달보다 {comparisonLabel}</p>
+        <div className={styles.amountRow}>
+          {spendingTrend === 'up' && <UpArrowIcon color="#EB0000" />}
+          {spendingTrend === 'down' && <DownArrowIcon color="#2946D8" />}
+          <p className={styles.amountRed}>{monthlySpending.toLocaleString()}원</p>
+        </div>
+        {comparisonLabel && <p className={styles.sub}>{comparisonLabel}</p>}
       </div>
 
-      <div className={styles.card}>
+      {/* 남은 예산 */}
+      <div
+        className={styles.card}
+        onClick={isBudgetUnset ? () => navigate('/budget') : undefined}
+        role={isBudgetUnset ? 'button' : undefined}
+        style={isBudgetUnset ? { cursor: 'pointer' } : undefined}
+      >
         <p className={styles.label}>남은 예산</p>
-        <p className={styles.amountBlue}>150,000원</p>
-        <p className={styles.sub}>목표까지 남았어요</p>
+        {!isBudgetUnset && (
+          <div className={styles.amountRow}>
+            {isOverBudget
+              ? <UpArrowIcon color="#EB0000" />
+              : <DownArrowIcon color="#2946D8" />
+            }
+            <p className={isOverBudget ? styles.amountRed : styles.amountBlue}>
+              {isOverBudget ? '-' : ''}{budgetAmount}
+            </p>
+          </div>
+        )}
+        <p className={styles.sub}>{budgetSub}</p>
       </div>
     </div>
   )

--- a/src/features/home/hooks/useHomeData.ts
+++ b/src/features/home/hooks/useHomeData.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+import { homeApi } from '../api/homeApi'
+
+export function useHomeData() {
+  return useQuery({
+    queryKey: ['home'],
+    queryFn: homeApi.getHomeData,
+    staleTime: 1000 * 60,
+  })
+}

--- a/src/features/home/index.tsx
+++ b/src/features/home/index.tsx
@@ -4,39 +4,54 @@ import SpendingSummary from './components/SpendingSummary'
 import GoalProgress from './components/GoalProgress'
 import EncouragementCard from './components/EncouragementCard'
 import SpendingQuestion from './components/SpendingQuestion'
+import HomeSkeleton from './components/HomeSkeleton'
+import { useHomeData } from './hooks/useHomeData'
 import styles from './Home.module.css'
 
-const mockHomeData = {
-  achievementPercent: 70,
-  monthlySpending: 350000,
-  comparisonPercent: 12,
-  // TODO: API 연결 시 소비 데이터 기반 자동 생성 메시지로 교체
-  encouragementMessage: '아직 시작 단계예요! 지금부터 조금씩 줄여볼까요?',
-  spendingQuestion: '오늘 계획하지 않은 소비가 있었나요?',
-  categories: [
-    { label: '식비', amount: 150000, color: '#286A6D' },
-    { label: '교통', amount: 80000, color: '#C7E3E3' },
-    { label: '쇼핑', amount: 120000, color: '#E5F2F1' },
-    { label: '저축', amount: 60000, color: '#C7E3E3' },
-    { label: '기타', amount: 85000, color: '#2F7F82' },
-  ],
-  goalCurrent: 350000,
-  goalTotal: 500000,
-}
-
 export default function Home() {
+  const { data, isLoading, isError, refetch } = useHomeData()
+
+  if (isLoading) return <HomeSkeleton />
+
+  if (isError) {
+    return (
+      <div className={styles.errorState}>
+        <p className={styles.errorText}>홈 정보를 불러오지 못했습니다.</p>
+        <button className={styles.retryButton} onClick={() => refetch()}>
+          다시 시도
+        </button>
+      </div>
+    )
+  }
+
+  if (!data) return null
+
+  const { monthlySpending, lastMonthSpending, budget, goalAmount, goalCurrent, categories, hasRecords } = data
+
+  const achievementPercent = goalAmount
+    ? Math.min(100, Math.round((goalCurrent / goalAmount) * 100))
+    : null
+
+  const topCategory = categories[0]
+  const topCategoryLabel = topCategory?.label ?? ''
+
   return (
     <main className={styles.main}>
-      <HomeBanner achievementPercent={mockHomeData.achievementPercent} />
+      <HomeBanner goalSet={goalAmount !== null} achievementPercent={achievementPercent} />
       <div className={styles.content}>
-        <CategoryChart categories={mockHomeData.categories} />
-        <SpendingSummary
-          monthlySpending={mockHomeData.monthlySpending}
-          comparisonPercent={mockHomeData.comparisonPercent}
+        <CategoryChart
+          categories={categories}
+          hasRecords={hasRecords}
+          topCategoryLabel={topCategoryLabel}
         />
-        <GoalProgress current={mockHomeData.goalCurrent} goal={mockHomeData.goalTotal} />
-        <EncouragementCard message={mockHomeData.encouragementMessage} />
-        <SpendingQuestion question={mockHomeData.spendingQuestion} />
+        <SpendingSummary
+          monthlySpending={monthlySpending}
+          lastMonthSpending={lastMonthSpending}
+          budget={budget}
+        />
+        <GoalProgress goalAmount={goalAmount} goalCurrent={goalCurrent} />
+        <EncouragementCard />
+        <SpendingQuestion />
       </div>
     </main>
   )

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -1,0 +1,16 @@
+export interface CategoryData {
+  label: string
+  amount: number
+  color: string
+  isOther: boolean
+}
+
+export interface HomeData {
+  monthlySpending: number
+  lastMonthSpending: number | null
+  budget: number | null
+  goalAmount: number | null
+  goalCurrent: number
+  categories: CategoryData[]
+  hasRecords: boolean
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,10 +1,19 @@
+import { useNavigate } from 'react-router-dom'
 import Header from '@/components/layout/Header'
 import Home from '@/features/home'
+import { useNotifications } from '@/features/notification/hooks/useNotifications'
 
 export default function HomePage() {
+  const navigate = useNavigate()
+  const { data: notifications } = useNotifications()
+  const unreadCount = notifications?.filter((n) => !n.isRead).length ?? 0
+
   return (
     <>
-      <Header />
+      <Header
+        onBellClick={() => navigate('/notification')}
+        unreadCount={unreadCount}
+      />
       <Home />
     </>
   )

--- a/src/shared/utils/currency.ts
+++ b/src/shared/utils/currency.ts
@@ -1,0 +1,3 @@
+export function formatKRW(amount: number): string {
+  return amount.toLocaleString('ko-KR') + '원'
+}

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -6,3 +6,11 @@ export function getFormattedDateLabel(date: Date = new Date()): string {
   const dayOfWeek = DAYS[date.getDay()]
   return `${month}월 ${day}일 ${dayOfWeek}요일`
 }
+
+export function getDayIndex(length: number): number {
+  const now = new Date()
+  const start = Date.UTC(now.getUTCFullYear(), 0, 1)
+  const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  const dayOfYear = Math.floor((today - start) / 86400000)
+  return dayOfYear % length
+}

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -7,10 +7,9 @@ export function getFormattedDateLabel(date: Date = new Date()): string {
   return `${month}월 ${day}일 ${dayOfWeek}요일`
 }
 
-export function getDayIndex(length: number): number {
-  const now = new Date()
-  const start = Date.UTC(now.getUTCFullYear(), 0, 1)
-  const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
-  const dayOfYear = Math.floor((today - start) / 86400000)
+export function getDayIndex(length: number, date: Date = new Date()): number {
+  const start = new Date(date.getFullYear(), 0, 1)
+  const today = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  const dayOfYear = Math.floor((today.getTime() - start.getTime()) / 86400000)
   return dayOfYear % length
 }


### PR DESCRIPTION
## 📌 작업 내용

- 이번달 소비 분석 리포트 섹션 레이아웃 구현
- 오늘 날짜 표시 UI 구현
- 목표 달성률 헤드라인 텍스트 구현 ("이번 달 목표 70% 달성했어요")
- 카테고리별 지출 막대그래프 UI 구현 (카드 사이즈에 맞게 그래프 크기 축소)
- 카테고리별 지출 데이터 조회 및 매핑 기능 구현
- 지출 패턴 코멘트 텍스트 자동 생성 로직 구현
- 이번 달 지출 금액 / 남은 예산 카드 UI 구현 (아이콘 추가)
- 전월 대비 지출 증감률(%) 계산 및 표시 기능 구현
- 목표까지 남은 금액 계산 로직 구현
- 오늘의 소비 질문 / 응원 메시지 하루 1개씩 자동 생성 로직 구현

## 📷 스크린 샷

<img width="337" height="851" alt="image" src="https://github.com/user-attachments/assets/28f27249-98bb-4bd7-9dd6-fadda0551248" />


## ⚠️ 참고 사항

-

## 🔗 관련 이슈

Closes #61 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈에 로딩 스켈레톤, 에러 상태(다시 시도) UI를 추가하고 서버/데이터 로딩 흐름으로 전환했습니다.
  * 카테고리 요약 차트(기록 없음 시 안내/버튼 포함), 예산·목표 진행률, 배너 문구 로직을 추가했습니다.
  * 헤더 알림에 읽지 않은 개수를 표시하고 알림 화면으로 이동할 수 있습니다.
* **개선**
  * 예산 미설정/초과/목표 미달성·달성 등 상태별 안내와 금액 표시를 고도화했습니다.
  * 홈 카드/차트/배너 등 UI 스타일을 전반적으로 정리하고, 클릭 요소의 접근성(버튼/키보드 처리)도 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->