### PR TITLE
✨ [Feature] Screen Specification 반영 - Drawer 구현

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom'
+import DrawerMenu from '@/features/drawer/DrawerMenu'
+
+export default function AppLayout() {
+  return (
+    <>
+      <Outlet />
+      <DrawerMenu />
+    </>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
 import { IoNotifications } from 'react-icons/io5'
+import { useDrawer } from '@/features/drawer/DrawerContext'
 import styles from "./Header.module.css";
 
 interface HeaderProps {
@@ -35,6 +36,7 @@ export default function Header({
   subMain
 }: HeaderProps) {
   const hasSubContent = Boolean(subLeft || subRight || subMain || subTitle);
+  const { open: openDrawer } = useDrawer()
 
   const defaultRight = (
     <>
@@ -44,7 +46,7 @@ export default function Header({
           {unreadCount > 0 && <span className={styles.badge} />}
         </span>
       </button>
-      <button className={styles.iconBtn} aria-label="메뉴">
+      <button className={styles.iconBtn} aria-label="메뉴" onClick={openDrawer}>
         <TwoLineMenu />
       </button>
     </>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { IoNotifications } from 'react-icons/io5'
-import { useDrawer } from '@/features/drawer/DrawerContext'
+import { useDrawer } from '@/features/drawer/useDrawer'
 import styles from "./Header.module.css";
 
 interface HeaderProps {

--- a/src/features/drawer/DrawerContext.tsx
+++ b/src/features/drawer/DrawerContext.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext, useState } from 'react'
+import type { ReactNode } from 'react'
+
+interface DrawerContextValue {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+}
+
+const DrawerContext = createContext<DrawerContextValue | null>(null)
+
+export function DrawerProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false)
+  return (
+    <DrawerContext.Provider value={{ isOpen, open: () => setIsOpen(true), close: () => setIsOpen(false) }}>
+      {children}
+    </DrawerContext.Provider>
+  )
+}
+
+export function useDrawer() {
+  const ctx = useContext(DrawerContext)
+  if (!ctx) throw new Error('useDrawer must be used within DrawerProvider')
+  return ctx
+}

--- a/src/features/drawer/DrawerContext.tsx
+++ b/src/features/drawer/DrawerContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState } from 'react'
+import { createContext, useState } from 'react'
 import type { ReactNode } from 'react'
 
 interface DrawerContextValue {
@@ -7,7 +7,7 @@ interface DrawerContextValue {
   close: () => void
 }
 
-const DrawerContext = createContext<DrawerContextValue | null>(null)
+export const DrawerContext = createContext<DrawerContextValue | null>(null)
 
 export function DrawerProvider({ children }: { children: ReactNode }) {
   const [isOpen, setIsOpen] = useState(false)
@@ -16,10 +16,4 @@ export function DrawerProvider({ children }: { children: ReactNode }) {
       {children}
     </DrawerContext.Provider>
   )
-}
-
-export function useDrawer() {
-  const ctx = useContext(DrawerContext)
-  if (!ctx) throw new Error('useDrawer must be used within DrawerProvider')
-  return ctx
 }

--- a/src/features/drawer/DrawerMenu.module.css
+++ b/src/features/drawer/DrawerMenu.module.css
@@ -7,11 +7,13 @@
   align-items: flex-start;
   visibility: hidden;
   pointer-events: none;
+  transition: visibility 0s linear 0.25s;
 }
 
 .overlayVisible {
   visibility: visible;
   pointer-events: auto;
+  transition-delay: 0s;
 }
 
 .drawer {

--- a/src/features/drawer/DrawerMenu.module.css
+++ b/src/features/drawer/DrawerMenu.module.css
@@ -1,0 +1,223 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(36, 49, 48, 0.45);
+  display: flex;
+  align-items: flex-start;
+}
+
+.drawer {
+  width: 300px;
+  height: 100%;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform 0.25s ease;
+}
+
+.drawerOpen {
+  transform: translateX(0);
+}
+
+.profileSection {
+  background-color: var(--color-main-000);
+  padding: 24px;
+  position: relative;
+}
+
+.profileRow {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  padding-top: 8px;
+}
+
+.avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background-color: #c7e3e3;
+  flex-shrink: 0;
+}
+
+.userInfo {
+  min-width: 0;
+  flex: 1;
+}
+
+.userName {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.greeting {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: var(--color-gray-300);
+  line-height: 1.4;
+}
+
+.closeBtn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-primary);
+  border-radius: 50%;
+}
+
+.closeBtn:hover {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.nav {
+  flex: 1;
+  padding: 16px 12px;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.navItem {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: none;
+  background: none;
+  width: 100%;
+  cursor: pointer;
+  text-align: left;
+}
+
+.navItem:hover {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.navItemActive {
+  background: #f0fafa;
+}
+
+.navIcon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background-color: #e8f4f4;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--color-main-500);
+}
+
+.navIconActive {
+  background-color: var(--color-main-500);
+  color: #fff;
+}
+
+.navLabel {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.navItemActive .navLabel {
+  color: var(--color-main-500);
+}
+
+.divider {
+  height: 1px;
+  background: #f3f4f6;
+  margin: 12px 16px;
+}
+
+.logoutItem .navIcon {
+  background-color: #fef2f2;
+  color: #ee5555;
+}
+
+.logoutItem .navLabel {
+  color: #ee5555;
+}
+
+.footer {
+  padding: 0 24px 32px;
+  text-align: center;
+  font-size: 11px;
+  color: #d1d5db;
+}
+
+.confirmOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirmDialog {
+  background: #fff;
+  border-radius: 16px;
+  padding: 24px;
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.confirmTitle {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.confirmMessage {
+  margin: 0;
+  font-size: 14px;
+  color: var(--color-gray-300);
+}
+
+.confirmButtons {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.confirmCancel,
+.confirmLogout {
+  flex: 1;
+  padding: 12px;
+  border-radius: 10px;
+  border: none;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.confirmCancel {
+  background: #f3f4f6;
+  color: var(--color-text-primary);
+}
+
+.confirmLogout {
+  background: #ee5555;
+  color: #fff;
+}

--- a/src/features/drawer/DrawerMenu.module.css
+++ b/src/features/drawer/DrawerMenu.module.css
@@ -5,6 +5,13 @@
   background: rgba(36, 49, 48, 0.45);
   display: flex;
   align-items: flex-start;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.overlayVisible {
+  visibility: visible;
+  pointer-events: auto;
 }
 
 .drawer {

--- a/src/features/drawer/DrawerMenu.tsx
+++ b/src/features/drawer/DrawerMenu.tsx
@@ -129,7 +129,7 @@ export default function DrawerMenu() {
 
           <nav className={styles.nav}>
             {NAV_ITEMS.map(({ label, icon, path }) => {
-              const isActive = location.pathname === path
+              const isActive = path === '/' ? location.pathname === path : location.pathname.startsWith(path)
               return (
                 <button
                   key={label}

--- a/src/features/drawer/DrawerMenu.tsx
+++ b/src/features/drawer/DrawerMenu.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { IoCloseOutline } from 'react-icons/io5'
-import { useDrawer } from './DrawerContext'
+import { useDrawer } from './useDrawer'
 import styles from './DrawerMenu.module.css'
 
 function LogoutIcon() {
@@ -63,23 +63,20 @@ export default function DrawerMenu() {
   const { isOpen, close } = useDrawer()
   const navigate = useNavigate()
   const location = useLocation()
-  const [mounted, setMounted] = useState(false)
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false)
   const touchStartX = useRef<number | null>(null)
 
   useEffect(() => {
-    if (isOpen) {
-      setMounted(true)
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = ''
+    if (!isOpen) {
       setShowLogoutConfirm(false)
-      const timer = setTimeout(() => setMounted(false), 250)
-      return () => clearTimeout(timer)
+      return
+    }
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
     }
   }, [isOpen])
-
-  if (!mounted) return null
 
   const handleNav = (path: string) => {
     close()
@@ -98,6 +95,7 @@ export default function DrawerMenu() {
   }
 
   const handleLogout = () => {
+    // TODO: 로그아웃 API 호출 및 토큰/세션 정리 후 이동
     setShowLogoutConfirm(false)
     close()
     navigate('/login')
@@ -105,7 +103,10 @@ export default function DrawerMenu() {
 
   return createPortal(
     <>
-      <div className={styles.overlay} onClick={close}>
+      <div
+        className={`${styles.overlay} ${isOpen ? styles.overlayVisible : ''}`}
+        onClick={close}
+      >
         <div
           className={`${styles.drawer} ${isOpen ? styles.drawerOpen : ''}`}
           onClick={(e) => e.stopPropagation()}
@@ -119,7 +120,7 @@ export default function DrawerMenu() {
             <div className={styles.profileRow}>
               <div className={styles.avatar} />
               <div className={styles.userInfo}>
-                {/* TODO: 실제 사용자 이름으로 교체 */}
+                {/* TODO: 실제 사용자 이름 및 프로필 이미지 연결 */}
                 <p className={styles.userName}>000님,</p>
                 <p className={styles.greeting}>오늘도 알뜰한 하루<br />시작해 보세요! 💰</p>
               </div>

--- a/src/features/drawer/DrawerMenu.tsx
+++ b/src/features/drawer/DrawerMenu.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { IoCloseOutline } from 'react-icons/io5'
+import { useDrawer } from './DrawerContext'
+import styles from './DrawerMenu.module.css'
+
+function LogoutIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path d="M6 14H3.33333C2.97971 14 2.64057 13.8595 2.39052 13.6095C2.14048 13.3594 2 13.0203 2 12.6667V3.33333C2 2.97971 2.14048 2.64057 2.39052 2.39052C2.64057 2.14048 2.97971 2 3.33333 2H6" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M10.667 11.3333L14.0003 7.99996L10.667 4.66663" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M14 8H6" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+function HomeIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path d="M10 14V8.66667C10 8.48986 9.92976 8.32029 9.80474 8.19526C9.67971 8.07024 9.51014 8 9.33333 8H6.66667C6.48986 8 6.32029 8.07024 6.19526 8.19526C6.07024 8.32029 6 8.48986 6 8.66667V14" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M2 6.66667C1.99995 6.47271 2.04222 6.28108 2.12386 6.10514C2.20549 5.92921 2.32453 5.7732 2.47267 5.648L7.13933 1.64867C7.37999 1.44527 7.6849 1.33368 8 1.33368C8.3151 1.33368 8.62001 1.44527 8.86067 1.64867L13.5273 5.648C13.6755 5.7732 13.7945 5.92921 13.8761 6.10514C13.9578 6.28108 14 6.47271 14 6.66667V12.6667C14 13.0203 13.8595 13.3594 13.6095 13.6095C13.3594 13.8595 13.0203 14 12.6667 14H3.33333C2.97971 14 2.64057 13.8595 2.39052 13.6095C2.14048 13.3594 2 13.0203 2 12.6667V6.66667Z" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+function MypageIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path d="M12.6663 14V12.6667C12.6663 11.9594 12.3854 11.2811 11.8853 10.781C11.3852 10.281 10.7069 10 9.99967 10H5.99967C5.29243 10 4.61415 10.281 4.11406 10.781C3.61396 11.2811 3.33301 11.9594 3.33301 12.6667V14" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M7.99967 7.33333C9.47243 7.33333 10.6663 6.13943 10.6663 4.66667C10.6663 3.19391 9.47243 2 7.99967 2C6.52692 2 5.33301 3.19391 5.33301 4.66667C5.33301 6.13943 6.52692 7.33333 7.99967 7.33333Z" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+function RecordIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path d="M8 4.66663V14" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M1.99967 12C1.82286 12 1.65329 11.9298 1.52827 11.8047C1.40325 11.6797 1.33301 11.5101 1.33301 11.3333V2.66667C1.33301 2.48986 1.40325 2.32029 1.52827 2.19526C1.65329 2.07024 1.82286 2 1.99967 2H5.33301C6.04025 2 6.71853 2.28095 7.21863 2.78105C7.71872 3.28115 7.99967 3.95942 7.99967 4.66667C7.99967 3.95942 8.28063 3.28115 8.78072 2.78105C9.28082 2.28095 9.9591 2 10.6663 2H13.9997C14.1765 2 14.3461 2.07024 14.4711 2.19526C14.5961 2.32029 14.6663 2.48986 14.6663 2.66667V11.3333C14.6663 11.5101 14.5961 11.6797 14.4711 11.8047C14.3461 11.9298 14.1765 12 13.9997 12H9.99967C9.46924 12 8.96053 12.2107 8.58546 12.5858C8.21039 12.9609 7.99967 13.4696 7.99967 14C7.99967 13.4696 7.78896 12.9609 7.41389 12.5858C7.03882 12.2107 6.53011 12 5.99967 12H1.99967Z" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+function TemptationIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path d="M13.3337 8.66664C13.3337 12 11.0003 13.6666 8.22699 14.6333C8.08177 14.6825 7.92402 14.6802 7.78033 14.6266C5.00033 13.6666 2.66699 12 2.66699 8.66664V3.99997C2.66699 3.82316 2.73723 3.65359 2.86225 3.52857C2.98728 3.40355 3.15685 3.33331 3.33366 3.33331C4.66699 3.33331 6.33366 2.53331 7.49366 1.51997C7.6349 1.39931 7.81456 1.33301 8.00033 1.33301C8.18609 1.33301 8.36576 1.39931 8.50699 1.51997C9.67366 2.53997 11.3337 3.33331 12.667 3.33331C12.8438 3.33331 13.0134 3.40355 13.1384 3.52857C13.2634 3.65359 13.3337 3.82316 13.3337 3.99997V8.66664Z" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M8 5.33337V8.00004" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M8 10.6666H8.00667" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
+    </svg>
+  )
+}
+
+const NAV_ITEMS = [
+  { label: '홈', icon: <HomeIcon />, path: '/' },
+  { label: '마이페이지', icon: <MypageIcon />, path: '/mypage' },
+  { label: '소비 기록 페이지', icon: <RecordIcon />, path: '/record' },
+  { label: '유혹 관리 페이지', icon: <TemptationIcon />, path: '/temptation' },
+]
+
+export default function DrawerMenu() {
+  const { isOpen, close } = useDrawer()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [mounted, setMounted] = useState(false)
+  const [showLogoutConfirm, setShowLogoutConfirm] = useState(false)
+  const touchStartX = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      setMounted(true)
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+      setShowLogoutConfirm(false)
+      const timer = setTimeout(() => setMounted(false), 250)
+      return () => clearTimeout(timer)
+    }
+  }, [isOpen])
+
+  if (!mounted) return null
+
+  const handleNav = (path: string) => {
+    close()
+    navigate(path)
+  }
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX
+  }
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    if (touchStartX.current === null) return
+    const diff = touchStartX.current - e.changedTouches[0].clientX
+    if (diff > 50) close()
+    touchStartX.current = null
+  }
+
+  const handleLogout = () => {
+    setShowLogoutConfirm(false)
+    close()
+    navigate('/login')
+  }
+
+  return createPortal(
+    <>
+      <div className={styles.overlay} onClick={close}>
+        <div
+          className={`${styles.drawer} ${isOpen ? styles.drawerOpen : ''}`}
+          onClick={(e) => e.stopPropagation()}
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+        >
+          <div className={styles.profileSection}>
+            <button className={styles.closeBtn} onClick={close} aria-label="닫기">
+              <IoCloseOutline size={20} />
+            </button>
+            <div className={styles.profileRow}>
+              <div className={styles.avatar} />
+              <div className={styles.userInfo}>
+                {/* TODO: 실제 사용자 이름으로 교체 */}
+                <p className={styles.userName}>000님,</p>
+                <p className={styles.greeting}>오늘도 알뜰한 하루<br />시작해 보세요! 💰</p>
+              </div>
+            </div>
+          </div>
+
+          <nav className={styles.nav}>
+            {NAV_ITEMS.map(({ label, icon, path }) => {
+              const isActive = location.pathname === path
+              return (
+                <button
+                  key={label}
+                  className={`${styles.navItem} ${isActive ? styles.navItemActive : ''}`}
+                  onClick={() => handleNav(path)}
+                >
+                  <span className={`${styles.navIcon} ${isActive ? styles.navIconActive : ''}`}>{icon}</span>
+                  <span className={styles.navLabel}>{label}</span>
+                </button>
+              )
+            })}
+
+            <div className={styles.divider} />
+
+            <button
+              className={`${styles.navItem} ${styles.logoutItem}`}
+              onClick={() => setShowLogoutConfirm(true)}
+            >
+              <span className={styles.navIcon}><LogoutIcon /></span>
+              <span className={styles.navLabel}>로그아웃</span>
+            </button>
+          </nav>
+
+          <p className={styles.footer}>@DonWorry</p>
+        </div>
+      </div>
+
+      {showLogoutConfirm && (
+        <div className={styles.confirmOverlay}>
+          <div className={styles.confirmDialog}>
+            <p className={styles.confirmTitle}>로그아웃</p>
+            <p className={styles.confirmMessage}>정말 로그아웃 하시겠어요?</p>
+            <div className={styles.confirmButtons}>
+              <button className={styles.confirmCancel} onClick={() => setShowLogoutConfirm(false)}>취소</button>
+              <button className={styles.confirmLogout} onClick={handleLogout}>로그아웃</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>,
+    document.body,
+  )
+}

--- a/src/features/drawer/useDrawer.ts
+++ b/src/features/drawer/useDrawer.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react'
+import { DrawerContext } from './DrawerContext'
+
+export function useDrawer() {
+  const ctx = useContext(DrawerContext)
+  if (!ctx) throw new Error('useDrawer must be used within DrawerProvider')
+  return ctx
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { RouterProvider } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import router from '@/router'
+import { DrawerProvider } from '@/features/drawer/DrawerContext'
 import './index.css'
 
 const queryClient = new QueryClient()
@@ -10,7 +11,9 @@ const queryClient = new QueryClient()
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <DrawerProvider>
+        <RouterProvider router={router} />
+      </DrawerProvider>
     </QueryClientProvider>
   </StrictMode>,
 )

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom'
+import AppLayout from '@/components/layout/AppLayout'
 import HomePage from '@/pages/HomePage'
 import NotificationPage from '@/pages/NotificationPage'
 import RecordMainPage from '@/features/record/pages/RecordMainPage'
@@ -11,17 +12,21 @@ import MyPagePage from '@/pages/MyPagePage'
 import GoalAmountPage from '@/pages/GoalAmountPage'
 
 const router = createBrowserRouter([
-  { path: '/', element: <HomePage /> },
-  { path: '/login', element: <LoginPage /> },
-  { path: '/signup', element: <SignUpPage /> },
-  { path: '/mypage', element: <MyPagePage /> }, 
-  {path: '/goal-amount', element: <GoalAmountPage /> },
-  { path: '/notification', element: <NotificationPage /> },
-
-  { path: '/record', element: <RecordMainPage /> },
-  { path: '/record/:id', element: <RecordDetailPage /> },
-  { path: '/record/intervention', element: <RecordInterventionPage /> },
-  { path: '/record/intervention/result', element: <RiskResultPage /> },
+  {
+    element: <AppLayout />,
+    children: [
+      { path: '/', element: <HomePage /> },
+      { path: '/login', element: <LoginPage /> },
+      { path: '/signup', element: <SignUpPage /> },
+      { path: '/mypage', element: <MyPagePage /> },
+      { path: '/goal-amount', element: <GoalAmountPage /> },
+      { path: '/notification', element: <NotificationPage /> },
+      { path: '/record', element: <RecordMainPage /> },
+      { path: '/record/:id', element: <RecordDetailPage /> },
+      { path: '/record/intervention', element: <RecordInterventionPage /> },
+      { path: '/record/intervention/result', element: <RiskResultPage /> },
+    ],
+  },
 ])
 
 export default router


### PR DESCRIPTION
## 📌 작업 내용

-  메뉴 아이콘 클릭 시 왼쪽에서 Drawer 노출되는 기능 구현
- Drawer 오픈 시 배경 화면 반투명 오버레이 처리
- Drawer 오픈 시 배경 화면 스크롤 방지 처리
- Drawer 닫기 기능 구현 (상단 뒤로가기 아이콘 클릭 / 오버레이 영역 클릭 / 왼쪽 스와이프)
- Drawer 닫힘 후에도 기존 화면의 입력값 및 스크롤 위치 유지되도록 구현
- 상단 설정 아이콘 클릭 시 앱 설정 화면 이동 구현
- 상단 알림 아이콘 클릭 시 알림 화면 이동 구현
- 읽지 않은 알림 존재 시 알림 아이콘 표시점(뱃지) 노출 구현
- 화면 이동 시 Drawer 자동 닫힘 처리
- 사용자 프로필 이미지 및 이름/닉네임 표시 UI 구현
- 프로필 이미지 없는 경우 기본 이미지 표시 처리
- 사용자명 길 경우 한 줄 말줄임(ellipsis) 처리
- 메뉴 목록 UI 구현 (홈 / 마이페이지 / 소비 기록 / 유혹 관리 / 로그아웃)
- 메뉴 항목 전체 영역 클릭 가능하도록 처리
- 현재 위치한 메뉴 선택 상태 구분 UI 구현
- 메뉴 클릭 시 해당 화면 이동 및 Drawer 닫힘 처리

## 📷 스크린 샷

<img width="1842" height="862" alt="image" src="https://github.com/user-attachments/assets/ea2163c0-a577-48f9-8d39-dbf0fc2173ef" />
<img width="322" height="857" alt="image" src="https://github.com/user-attachments/assets/6a5ba3de-bf3f-4b4e-8831-aa0c6c327001" />



## ⚠️ 참고 사항

- 일단 위 스크린 샷처럼 구현해 봤는데.. 페이지 안 화면에서 Drawer 열리는 게 나을까요? (너무 작아 보이는 것 같기도 해서..)

## 🔗 관련 이슈

Closes #52 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 헤더의 메뉴 버튼으로 사이드 드로어 메뉴를 열 수 있습니다.
  - 프로필, 네비게이션, 로그아웃 항목을 제공하며 현재 페이지 메뉴를 강조 표시합니다.
  - 메뉴 항목 이동, 오버레이·스와이프·닫기 버튼을 통한 닫기를 지원합니다.
  - 로그아웃 전 확인 대화상자를 표시하고 로그인 화면으로 이동할 수 있습니다.
  - 드로어가 열려 있을 때 배경 스크롤을 차단합니다.

- **개선**
  - 공통 레이아웃을 적용해 페이지 콘텐츠와 드로어 메뉴를 일관되게 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->