### PR TITLE
✨ [Feature] Screen Specification 반영 - Drawer 로그아웃 모달창 구현

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { IoNotifications } from 'react-icons/io5'
-import { useDrawer } from '@/features/drawer/useDrawer'
+import { useDrawer } from '@/features/drawer/DrawerContext'
 import styles from './Header.module.css'
 
 interface HeaderProps {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import { IoNotifications } from 'react-icons/io5'
-import { useDrawer } from '@/features/drawer/DrawerContext'
+import { useDrawer } from '@/features/drawer/useDrawer'
 import styles from './Header.module.css'
 
 interface HeaderProps {

--- a/src/features/drawer/DrawerMenu.module.css
+++ b/src/features/drawer/DrawerMenu.module.css
@@ -175,7 +175,7 @@
   position: fixed;
   inset: 0;
   z-index: 1100;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(36, 49, 48, 0.5);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -183,50 +183,65 @@
 
 .confirmDialog {
   background: #fff;
-  border-radius: 16px;
-  padding: 24px;
+  border-radius: 20px;
+  padding: 28px 24px 24px;
   width: 280px;
+  box-shadow: 0px 25px 25px rgba(0, 0, 0, 0.25);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  align-items: center;
+}
+
+.confirmIconWrap {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #fff3f3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ee5555;
+  margin-bottom: 16px;
 }
 
 .confirmTitle {
-  margin: 0;
-  font-size: 16px;
+  margin: 0 0 4px;
+  font-size: 17px;
   font-weight: 700;
-  color: var(--color-text-primary);
+  color: #243130;
 }
 
 .confirmMessage {
-  margin: 0;
-  font-size: 14px;
-  color: var(--color-gray-300);
+  margin: 0 0 24px;
+  font-size: 13px;
+  color: #7a9190;
 }
 
 .confirmButtons {
   display: flex;
-  gap: 8px;
-  margin-top: 8px;
+  gap: 12px;
+  width: 100%;
 }
 
 .confirmCancel,
 .confirmLogout {
   flex: 1;
-  padding: 12px;
-  border-radius: 10px;
-  border: none;
+  height: 46px;
+  border-radius: 12px;
   font-size: 14px;
-  font-weight: 600;
+  font-weight: 700;
   cursor: pointer;
 }
 
 .confirmCancel {
-  background: #f3f4f6;
-  color: var(--color-text-primary);
+  background: #fff;
+  border: 1.5px solid #e0e0e0;
+  color: #5b6b6a;
 }
 
 .confirmLogout {
   background: #ee5555;
+  border: none;
   color: #fff;
+  box-shadow: 0px 4px 6px rgba(220, 80, 80, 0.3);
 }

--- a/src/features/drawer/DrawerMenu.tsx
+++ b/src/features/drawer/DrawerMenu.tsx
@@ -65,6 +65,17 @@ export default function DrawerMenu() {
   const location = useLocation()
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false)
   const touchStartX = useRef<number | null>(null)
+  const cancelBtnRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (!showLogoutConfirm) return
+    cancelBtnRef.current?.focus()
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setShowLogoutConfirm(false)
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [showLogoutConfirm])
 
   useEffect(() => {
     if (!isOpen) {
@@ -159,14 +170,19 @@ export default function DrawerMenu() {
 
       {showLogoutConfirm && (
         <div className={styles.confirmOverlay}>
-          <div className={styles.confirmDialog}>
+          <div
+            className={styles.confirmDialog}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="logout-dialog-title"
+          >
             <div className={styles.confirmIconWrap}>
               <LogoutIcon size={24} />
             </div>
-            <p className={styles.confirmTitle}>로그아웃</p>
+            <p id="logout-dialog-title" className={styles.confirmTitle}>로그아웃</p>
             <p className={styles.confirmMessage}>정말 로그아웃 하시겠습니까?</p>
             <div className={styles.confirmButtons}>
-              <button className={styles.confirmCancel} onClick={() => setShowLogoutConfirm(false)}>취소</button>
+              <button ref={cancelBtnRef} className={styles.confirmCancel} onClick={() => setShowLogoutConfirm(false)}>취소</button>
               <button className={styles.confirmLogout} onClick={handleLogout}>로그아웃</button>
             </div>
           </div>

--- a/src/features/drawer/DrawerMenu.tsx
+++ b/src/features/drawer/DrawerMenu.tsx
@@ -66,12 +66,34 @@ export default function DrawerMenu() {
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false)
   const touchStartX = useRef<number | null>(null)
   const cancelBtnRef = useRef<HTMLButtonElement>(null)
+  const confirmLogoutBtnRef = useRef<HTMLButtonElement>(null)
+  const logoutTriggerBtnRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
     if (!showLogoutConfirm) return
     cancelBtnRef.current?.focus()
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setShowLogoutConfirm(false)
+      if (e.key === 'Escape') {
+        setShowLogoutConfirm(false)
+        logoutTriggerBtnRef.current?.focus()
+        return
+      }
+      if (e.key === 'Tab') {
+        const focusable = [cancelBtnRef.current, confirmLogoutBtnRef.current].filter(Boolean) as HTMLElement[]
+        const first = focusable[0]
+        const last = focusable[focusable.length - 1]
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault()
+            last?.focus()
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault()
+            first?.focus()
+          }
+        }
+      }
     }
     document.addEventListener('keydown', handleKeyDown)
     return () => document.removeEventListener('keydown', handleKeyDown)
@@ -156,6 +178,7 @@ export default function DrawerMenu() {
             <div className={styles.divider} />
 
             <button
+              ref={logoutTriggerBtnRef}
               className={`${styles.navItem} ${styles.logoutItem}`}
               onClick={() => setShowLogoutConfirm(true)}
             >
@@ -182,8 +205,15 @@ export default function DrawerMenu() {
             <p id="logout-dialog-title" className={styles.confirmTitle}>로그아웃</p>
             <p className={styles.confirmMessage}>정말 로그아웃 하시겠습니까?</p>
             <div className={styles.confirmButtons}>
-              <button ref={cancelBtnRef} className={styles.confirmCancel} onClick={() => setShowLogoutConfirm(false)}>취소</button>
-              <button className={styles.confirmLogout} onClick={handleLogout}>로그아웃</button>
+              <button
+                ref={cancelBtnRef}
+                className={styles.confirmCancel}
+                onClick={() => {
+                  setShowLogoutConfirm(false)
+                  logoutTriggerBtnRef.current?.focus()
+                }}
+              >취소</button>
+              <button ref={confirmLogoutBtnRef} className={styles.confirmLogout} onClick={handleLogout}>로그아웃</button>
             </div>
           </div>
         </div>

--- a/src/features/drawer/DrawerMenu.tsx
+++ b/src/features/drawer/DrawerMenu.tsx
@@ -5,9 +5,9 @@ import { IoCloseOutline } from 'react-icons/io5'
 import { useDrawer } from './useDrawer'
 import styles from './DrawerMenu.module.css'
 
-function LogoutIcon() {
+function LogoutIcon({ size = 16 }: { size?: number }) {
   return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+    <svg width={size} height={size} viewBox="0 0 16 16" fill="none">
       <path d="M6 14H3.33333C2.97971 14 2.64057 13.8595 2.39052 13.6095C2.14048 13.3594 2 13.0203 2 12.6667V3.33333C2 2.97971 2.14048 2.64057 2.39052 2.39052C2.64057 2.14048 2.97971 2 3.33333 2H6" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
       <path d="M10.667 11.3333L14.0003 7.99996L10.667 4.66663" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
       <path d="M14 8H6" stroke="currentColor" strokeWidth="1.33333" strokeLinecap="round" strokeLinejoin="round"/>
@@ -160,8 +160,11 @@ export default function DrawerMenu() {
       {showLogoutConfirm && (
         <div className={styles.confirmOverlay}>
           <div className={styles.confirmDialog}>
+            <div className={styles.confirmIconWrap}>
+              <LogoutIcon size={24} />
+            </div>
             <p className={styles.confirmTitle}>로그아웃</p>
-            <p className={styles.confirmMessage}>정말 로그아웃 하시겠어요?</p>
+            <p className={styles.confirmMessage}>정말 로그아웃 하시겠습니까?</p>
             <div className={styles.confirmButtons}>
               <button className={styles.confirmCancel} onClick={() => setShowLogoutConfirm(false)}>취소</button>
               <button className={styles.confirmLogout} onClick={handleLogout}>로그아웃</button>


### PR DESCRIPTION
## 📌 작업 내용

- 로그아웃 메뉴 클릭 시 로그아웃 모달창 기능 구현

## 📷 스크린 샷

<img width="1820" height="842" alt="image" src="https://github.com/user-attachments/assets/0c0a38f0-5ea8-45b1-a2d7-cf1a4c1177c2" />


## ⚠️ 참고 사항

-

## 🔗 관련 이슈

Closes #53 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 로그아웃 확인 모달의 색상, 여백, 모서리, 그림자 및 정렬을 전반적으로 개선했습니다.
  * 확인 아이콘을 추가하고 제목, 안내 문구, 버튼 스타일을 더욱 명확하게 조정했습니다.
  * 모달이 열리면 취소 버튼에 자동으로 포커스되며, 키보드로도 편리하게 탐색할 수 있습니다.
  * Escape 키로 모달을 닫을 수 있고, 닫힌 후 로그아웃 버튼으로 포커스가 복원됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->