### PR TITLE
✨ [Feature] 위시리스트 상세페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-icons": "^5.7.0",
-        "react-router-dom": "^7.16.0",
+        "react-router-dom": "^7.18.1",
         "tailwindcss": "^4.3.0",
         "zustand": "^5.0.14"
       },
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3096,9 +3096,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
-      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
+      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -3118,12 +3118,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
-      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "version": "7.18.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
+      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.16.0"
+        "react-router": "7.18.1"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-icons": "^5.7.0",
-    "react-router-dom": "^7.16.0",
+    "react-router-dom": "^7.18.1",
     "tailwindcss": "^4.3.0",
     "zustand": "^5.0.14"
   },

--- a/src/components/layout/ProductForm.module.css
+++ b/src/components/layout/ProductForm.module.css
@@ -24,13 +24,21 @@
 }
 
 .textInput {
-  flex: 1;
+  width: 100%;
   border: none;
-  border-bottom: 2px solid #dddddd;
+  border-bottom: 2px solid var(--Gray-100, #DDDDDD);
   font-size: 14px;
   font-weight: bold;
+  font-family: inherit;
   padding: 4px 0;
   outline: none;
+  resize: none;
+  box-sizing: border-box;
+}
+
+.textInput::placeholder {
+  font-weight: normal;
+  color: var(--Gray-300, #5B6B6A);
 }
 
 .priceWrapper {

--- a/src/components/layout/ProductForm.module.css
+++ b/src/components/layout/ProductForm.module.css
@@ -56,8 +56,7 @@
   outline: none;
 }
 
-.priceInput::placeholder,
-.textInput::placeholder {
+.priceInput::placeholder {
   color: #dddddd;
   font-weight: bold;
 }

--- a/src/components/layout/ProductForm.tsx
+++ b/src/components/layout/ProductForm.tsx
@@ -168,12 +168,14 @@ export function ProductForm({ formId = 'product-form', showTimeSelector = true, 
 
       <div className={styles.field}>
         <label htmlFor="reason" className={styles.label}>사고 싶은 이유 (선택)</label>
-        <input
+        <textarea
           id="reason"
           className={styles.textInput}
           placeholder="스트레스 받아서? 진짜 필요해서?"
           value={data.reason}
-          onChange={(e) => setData({...data, reason: e.target.value})} />
+          onChange={(e) => setData({...data, reason: e.target.value})}
+          rows={3}
+          />
       </div>
     </form>
   );

--- a/src/features/temptation/Temptation.tsx
+++ b/src/features/temptation/Temptation.tsx
@@ -3,24 +3,17 @@ import { PiListBold } from "react-icons/pi";
 import { IoNotifications } from "react-icons/io5";
 import { IoIosArrowBack } from "react-icons/io";
 import SearchBar from './components/SearchBar';
-import { useMemo, useState } from 'react';
 import styles from './Temptation.module.css'
 import { useNow } from './hooks/useNow';
 import TemptationMain from './pages/TemptationMain';
 import { Search } from './pages/Search';
-import { MOCK_PRODUCTS } from './mockData';
+import { useWishlistContext } from './hooks/WishlistContext';
 
 export default function Temptation() {
-  const [keyword, setKeyword] = useState('');
+  const { keyword, setKeyword, filteredProducts } = useWishlistContext();
   useNow();
 
   const trimmedKeyword = keyword.trim();
-
-  const filteredProducts = useMemo(() => {
-    const trimmed = keyword.trim().toLowerCase();
-    if (!trimmed) return MOCK_PRODUCTS;
-    return MOCK_PRODUCTS.filter((p) => p.name.toLowerCase().includes(trimmed));
-  }, [keyword]);
 
   return (
     <>
@@ -47,7 +40,7 @@ export default function Temptation() {
       {trimmedKeyword ? (
         <Search keyword={keyword} filteredProducts={filteredProducts} />
       ) : (
-        <TemptationMain keyword={keyword} />
+        <TemptationMain />
       )}
     </>
   )

--- a/src/features/temptation/components/ConfirmDialog.module.css
+++ b/src/features/temptation/components/ConfirmDialog.module.css
@@ -1,0 +1,81 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.card {
+  width: 320px;
+  background-color: #fff;
+  border-radius: 20px;
+  padding: 32px 24px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.icon {
+  color: var(--Red, #EB0000);
+  margin-bottom: 20px;
+}
+
+.title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--Primary, #243130);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.description {
+  font-size: 14px;
+  color: var(--Gray-300, #5B6B6A);
+  margin: 8px 0 0;
+  line-height: 1.5;
+}
+
+.errorText {
+  font-size: 13px;
+  color: var(--Red, #EB0000);
+  margin: 12px 0 0;
+}
+
+.buttonRow {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+  margin-top: 28px;
+}
+
+.cancelBtn,
+.confirmBtn {
+  flex: 1;
+  height: 48px;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: 700;
+  cursor: pointer;
+  border: none;
+}
+
+.cancelBtn {
+  background-color: #fff;
+  border: 1.5px solid var(--Main-400, #389698);
+  color: var(--Main-400, #389698);
+}
+
+.confirmBtn {
+  background-color: var(--Main-400, #389698);
+  color: #fff;
+}
+
+.cancelBtn:disabled,
+.confirmBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/features/temptation/components/ConfirmDialog.tsx
+++ b/src/features/temptation/components/ConfirmDialog.tsx
@@ -1,0 +1,48 @@
+import { IoWarningOutline } from 'react-icons/io5';
+import styles from './ConfirmDialog.module.css';
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  description?: string;
+  cancelText?: string;
+  confirmText?: string;
+  isLoading?: boolean;
+  errorMessage?: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export const ConfirmDialog = ({
+  isOpen,
+  title,
+  description,
+  cancelText = '취소',
+  confirmText = '확인',
+  isLoading = false,
+  errorMessage,
+  onCancel,
+  onConfirm,
+}: ConfirmDialogProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className={styles.overlay}>
+      <div className={styles.card}>
+        <IoWarningOutline size={48} className={styles.icon} />
+        <p className={styles.title}>{title}</p>
+        {description && <p className={styles.description}>{description}</p>}
+        {errorMessage && <p className={styles.errorText}>{errorMessage}</p>}
+
+        <div className={styles.buttonRow}>
+          <button className={styles.cancelBtn} onClick={onCancel} disabled={isLoading}>
+            {cancelText}
+          </button>
+          <button className={styles.confirmBtn} onClick={onConfirm} disabled={isLoading}>
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/temptation/components/ConfirmDialog.tsx
+++ b/src/features/temptation/components/ConfirmDialog.tsx
@@ -79,7 +79,7 @@ export const ConfirmDialog = ({
       className={styles.card}
       ref={cardRef}
       role="dialog"
-      aria-model="true"
+      aria-modal="true"
       aria-labelledby="confirm-dialog-title"
       aria-describedby={description ? 'confirm-dialog-description' : undefined}>
         <IoWarningOutline size={48} className={styles.icon} aria-hidden="true" />

--- a/src/features/temptation/components/ConfirmDialog.tsx
+++ b/src/features/temptation/components/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import { IoWarningOutline } from 'react-icons/io5';
 import styles from './ConfirmDialog.module.css';
+import { useRef, useEffect } from 'react';
 
 interface ConfirmDialogProps {
   isOpen: boolean;
@@ -24,21 +25,80 @@ export const ConfirmDialog = ({
   onCancel,
   onConfirm,
 }: ConfirmDialogProps) => {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const cancelBtnRef = useRef<HTMLButtonElement>(null);
+  const triggerElementRef = useRef<HTMLElement | null>(null);
+  
+  useEffect(() => {
+    if (isOpen) {
+      triggerElementRef.current = document.activeElement as HTMLElement;
+      cancelBtnRef.current?.focus();
+    } else if (triggerElementRef.current) {
+      triggerElementRef.current.focus();
+      triggerElementRef.current = null;
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (!isLoading) onCancel();
+        return;
+      }
+
+      if (e.key === 'Tab' && cardRef.current) {
+        const focusables = cardRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusables.length === 0) return;
+
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, isLoading, onCancel]);
+  
   if (!isOpen) return null;
 
   return (
     <div className={styles.overlay}>
-      <div className={styles.card}>
-        <IoWarningOutline size={48} className={styles.icon} />
-        <p className={styles.title}>{title}</p>
-        {description && <p className={styles.description}>{description}</p>}
-        {errorMessage && <p className={styles.errorText}>{errorMessage}</p>}
+      <div
+      className={styles.card}
+      ref={cardRef}
+      role="dialog"
+      aria-model="true"
+      aria-labelledby="confirm-dialog-title"
+      aria-describedby={description ? 'confirm-dialog-description' : undefined}>
+        <IoWarningOutline size={48} className={styles.icon} aria-hidden="true" />
+        <p className={styles.title} id="confirm-dialog-title">{title}</p>
+        {description && <p className={styles.description} id="confirm-dialog-description">{description}</p>}
+        {errorMessage && <p className={styles.errorText} role="alert">{errorMessage}</p>}
 
         <div className={styles.buttonRow}>
-          <button className={styles.cancelBtn} onClick={onCancel} disabled={isLoading}>
+          <button
+          className={styles.cancelBtn}
+          ref={cancelBtnRef}
+          onClick={onCancel}
+          disabled={isLoading}>
             {cancelText}
           </button>
-          <button className={styles.confirmBtn} onClick={onConfirm} disabled={isLoading}>
+          <button
+          className={styles.confirmBtn}
+          onClick={onConfirm}
+          disabled={isLoading}>
             {confirmText}
           </button>
         </div>

--- a/src/features/temptation/components/temptationInfo/ActionButton.module.css
+++ b/src/features/temptation/components/temptationInfo/ActionButton.module.css
@@ -1,0 +1,32 @@
+.wrapper {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: calc(100% - 48px);
+  max-width: 342px;
+  display: flex;
+  gap: 10px;
+}
+
+.editBtn,
+.giveUpBtn {
+  flex: 1;
+  height: 52px;
+  border-radius: 15px;
+  border: none;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.editBtn {
+  background-color: var(--Main-000, #E5F2F1);
+  color: var(--Main-500, #2F7F82);
+  border: 1.5px solid var(--Main-300, #8FC4C0);
+}
+
+.giveUpBtn {
+  background-color: var(--Main-500, #2F7F82);
+  color: #fff;
+}

--- a/src/features/temptation/components/temptationInfo/ActionButton.tsx
+++ b/src/features/temptation/components/temptationInfo/ActionButton.tsx
@@ -1,0 +1,15 @@
+import styles from './ActionButton.module.css';
+
+interface ActionButtonProps {
+  onEdit: () => void;
+  onGiveUp: () => void;
+}
+
+export const ActionButton = ({ onEdit, onGiveUp }: ActionButtonProps) => {
+  return (
+    <div className={styles.wrapper}>
+      <button className={styles.editBtn} onClick={onEdit}>수정하기</button>
+      <button className={styles.giveUpBtn} onClick={onGiveUp}>포기하기</button>
+    </div>
+  );
+};

--- a/src/features/temptation/components/temptationInfo/InfoBox.module.css
+++ b/src/features/temptation/components/temptationInfo/InfoBox.module.css
@@ -1,0 +1,96 @@
+.box {
+  width: 360px;
+  border: 1.5px solid var(--Gray-100, #DDDDDD);
+  border-radius: 15px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+.section {
+  padding: 15px 0;
+}
+
+.section:first-child {
+  padding-top: 0;
+}
+
+.divider {
+  border-top: 1.5px solid var(--Gray-100, #DDDDDD);
+  margin-left: -20px;
+  margin-right: -20px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
+.sectionLabel {
+  font-size: 14px;
+  font-weight: bold;
+  color: var(--Gray-300, #5B6B6A);
+  margin: 0 0 3px;
+}
+
+.price {
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--Primary, #243130);
+  margin: 0;
+}
+
+.priceUnit {
+  font-size: 14px;
+  font-weight: bold;
+  margin-left: 4px;
+}
+
+.reasonText {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--Primary, #243130);
+  min-height: 60px;
+  white-space: pre-wrap;
+  margin: 0;
+}
+
+.linkRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.linkText {
+  flex: 1;
+  min-width: 0;
+  color: var(--Primary, #243130);
+  font-size: 14px;
+  text-decoration: underline;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.copyBtn {
+  display: flex;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 5px;
+  color: var(--Gray-300, #5B6B6A);
+  background-color: var(--Gray-100, #DDDDDD);
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s ease;
+}
+
+.copyBtn:hover {
+  background-color: var(--Gray-200, #9CA4A3);
+}
+
+.errorText {
+  color: #EB0000;
+  font-size: 12px;
+  margin: 4px 0 0;
+}

--- a/src/features/temptation/components/temptationInfo/InfoBox.tsx
+++ b/src/features/temptation/components/temptationInfo/InfoBox.tsx
@@ -17,9 +17,11 @@ export const InfoBox = ({ price, reason, link }: InfoBoxProps) => {
     try {
       await navigator.clipboard.writeText(link);
       setCopied(true);
+      setLinkError(false);
       setTimeout(() => setCopied(false), 1500);
     } catch {
       setLinkError(true);
+      setCopied(false);
     }
   };
 

--- a/src/features/temptation/components/temptationInfo/InfoBox.tsx
+++ b/src/features/temptation/components/temptationInfo/InfoBox.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { FaCopy } from "react-icons/fa";
+import styles from './InfoBox.module.css';
+
+interface InfoBoxProps {
+  price: number;
+  reason?: string;
+  link?: string;
+}
+
+export const InfoBox = ({ price, reason, link }: InfoBoxProps) => {
+  const [copied, setCopied] = useState(false);
+  const [linkError, setLinkError] = useState(false);
+
+  const handleCopy = async () => {
+    if (!link) return;
+    try {
+      await navigator.clipboard.writeText(link);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setLinkError(true);
+    }
+  };
+
+  return (
+    <div className={styles.box}>
+      <div className={styles.section}>
+        <p className={styles.sectionLabel}>상품 가격</p>
+        <p className={styles.price}>
+          {price.toLocaleString()}
+          <span className={styles.priceUnit}>원</span>
+        </p>
+      </div>
+
+      <div className={styles.section}>
+        <p className={styles.sectionLabel}>사고 싶은 이유</p>
+        <p className={styles.reasonText}>{reason || '작성한 이유가 없습니다.'}</p>
+      </div>
+
+      {link && (
+        <div className={`${styles.section} ${styles.divider}`}>
+          <p className={styles.sectionLabel}>상품 링크</p>
+          <div className={styles.linkRow}>
+            <a href={link} target="_blank" rel="noreferrer" className={styles.linkText}>
+              {link}
+            </a>
+            <button className={styles.copyBtn} onClick={handleCopy} aria-label="링크 복사">
+              <FaCopy size={15} />
+            </button>
+          </div>
+          {linkError && <p className={styles.errorText}>상품 링크를 복사하지 못했습니다.</p>}
+          {copied && <p className={styles.errorText} style={{ color: '#008D02' }}>상품 링크가 복사되었습니다.</p>}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/features/temptation/components/temptationInfo/InfoHeader.module.css
+++ b/src/features/temptation/components/temptationInfo/InfoHeader.module.css
@@ -1,0 +1,39 @@
+.productHeader {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.textGroup {
+  display: flex;
+  flex-direction: column;
+  margin-top: 20px;
+}
+
+.categoryChip {
+  display: flex;
+  min-width: 55px;
+  height: 24px;
+  color: var(--White, #FEFEFE);
+  background-color: var(--Main-500, #2F7F82);
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 10px;
+  padding: 0 10px;
+  align-self: flex-start;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.25);
+}
+
+.productName {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--Primary, #243130);
+}

--- a/src/features/temptation/components/temptationInfo/InfoHeader.tsx
+++ b/src/features/temptation/components/temptationInfo/InfoHeader.tsx
@@ -1,0 +1,20 @@
+import { CategoryIcon } from '@/assets/icons/CategoryIcon';
+import type { Category } from '../../types';
+import styles from './InfoHeader.module.css';
+
+interface InfoHeaderProps {
+  category: Category;
+  name: string;
+}
+
+export const InfoHeader = ({ category, name }: InfoHeaderProps) => {
+  return (
+    <div className={styles.productHeader}>
+      <CategoryIcon category={category} size={55} />
+      <div className={styles.textGroup}>
+        <span className={styles.categoryChip}>{category}</span>
+        <h2 className={styles.productName}>{name}</h2>
+      </div>
+    </div>
+  );
+};

--- a/src/features/temptation/components/temptationInfo/RemainingTime.module.css
+++ b/src/features/temptation/components/temptationInfo/RemainingTime.module.css
@@ -1,0 +1,37 @@
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 15px 0;
+  align-items: center;
+  gap: 2px;
+}
+
+.label {
+  width: 340px;
+  text-align: left;
+  font-size: 14px;
+  font-weight: bold;
+  color: var(--Gray-300, #5B6B6A);
+}
+
+.time {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--Sub-200, #FE9B9A);
+}
+
+.barTrack {
+  width: 340px;
+  height: 15px;
+  border-radius: 999px;
+  background-color: var(--Main-100, #E5F2F1);
+  overflow: hidden;
+}
+
+.barFill {
+  height: 100%;
+  background-color: var(--Main-400, #389698);
+  border-radius: 300px;
+  transition: width 1s linear;
+}

--- a/src/features/temptation/components/temptationInfo/RemainingTime.tsx
+++ b/src/features/temptation/components/temptationInfo/RemainingTime.tsx
@@ -1,0 +1,25 @@
+import { useNow } from '../../hooks/useNow';
+import { formatDetailTimer } from '../../utils/formatDetailTimer';
+import { remainPercent } from '../../utils/remainPercent';
+import styles from './RemainingTime.module.css';
+
+interface RemainingTimeProps {
+  deadline: Date;
+  createdAt?: Date;
+}
+
+export const RemainingTime = ({ deadline, createdAt }: RemainingTimeProps) => {
+  useNow(1000);
+
+  const percent = remainPercent(deadline, createdAt ?? null);
+
+  return (
+    <div className={styles.wrapper}>
+      <span className={styles.label}>남은 고민 시간</span>
+      <span className={styles.time}>{formatDetailTimer(deadline)}</span>
+      <div className={styles.barTrack}>
+        <div className={styles.barFill} style={{ width: `${percent}%` }} />
+      </div>
+    </div>
+  );
+};

--- a/src/features/temptation/components/temptationMain/ProductItem.module.css
+++ b/src/features/temptation/components/temptationMain/ProductItem.module.css
@@ -12,6 +12,21 @@
   align-items: flex-start;
 }
 
+.itemInfoButton {
+  display: flex;
+  flex-direction: column;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  align-items: flex-start;
+  cursor: pointer;
+  flex: 1;
+}
+
 .itemPrice {
   font-size: 12px;
   margin-top: -5px;

--- a/src/features/temptation/components/temptationMain/ProductItem.tsx
+++ b/src/features/temptation/components/temptationMain/ProductItem.tsx
@@ -17,13 +17,24 @@ export const ProductItem = ({ product, onDelete }: ProductItemProps) => {
   }
 
   return (
-    <div className={styles.itemContainer} onClick={handleClick} style={{ cursor: 'pointer' }}>
+    <div className={styles.itemContainer}>
       <div className={styles.itemInfo}>
-        <div>
+        <button
+          type="button"
+          className={styles.itemInfoButton}
+          onClick={handleClick}
+          aria-label={`${name} 상세 보기`}>
           <p>{name}</p>
           <p className={styles.itemPrice}>{price.toLocaleString()}원</p>
-        </div>
-        <button className={styles.deleteBtn} aria-label="상품 삭제" onClick={() => onDelete(id)}>
+        </button>
+        <button
+          type="button"
+          className={styles.deleteBtn}
+          aria-label="상품 삭제"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(id);
+          }}>
           ✕
         </button>
       </div>

--- a/src/features/temptation/components/temptationMain/ProductItem.tsx
+++ b/src/features/temptation/components/temptationMain/ProductItem.tsx
@@ -1,6 +1,7 @@
 import { formatRemainingTime } from '../../utils/formatTimer';
 import type { Product } from '@/features/temptation/types';
 import styles from './ProductItem.module.css';
+import { useNavigate } from 'react-router-dom';
 
 interface ProductItemProps {
   product: Product;
@@ -8,10 +9,15 @@ interface ProductItemProps {
 }
 
 export const ProductItem = ({ product, onDelete }: ProductItemProps) => {
+  const navigate = useNavigate();
   const { id, name, price, time } = product;
 
+  const handleClick = () => {
+    navigate(`/temptation/${id}`);
+  }
+
   return (
-    <div className={styles.itemContainer}>
+    <div className={styles.itemContainer} onClick={handleClick} style={{ cursor: 'pointer' }}>
       <div className={styles.itemInfo}>
         <div>
           <p>{name}</p>

--- a/src/features/temptation/components/temptationSearch/SearchProductItem.module.css
+++ b/src/features/temptation/components/temptationSearch/SearchProductItem.module.css
@@ -8,6 +8,11 @@
   border-radius: 15px;
   padding: 10px 12px;
   margin-bottom: 3px;
+  background: none;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
 }
 
 .top {

--- a/src/features/temptation/components/temptationSearch/SearchProductItem.tsx
+++ b/src/features/temptation/components/temptationSearch/SearchProductItem.tsx
@@ -3,6 +3,7 @@ import { formatRemainingTime } from '../../utils/formatTimer';
 import { highlightSearch } from '../../utils/highlightSearch';
 import type { Product } from '@/features/temptation/types';
 import styles from './SearchProductItem.module.css';
+import { useNavigate } from 'react-router-dom';
 
 interface SearchProductItemProps {
   product: Product;
@@ -10,10 +11,15 @@ interface SearchProductItemProps {
 }
 
 export const SearchProductItem = ({ product, keyword }: SearchProductItemProps) => {
-  const { name, category, price, time } = product;
+  const navigate = useNavigate();
+  const { id, name, category, price, time } = product;
+
+  const handleClick = () => {
+    navigate(`/temptation/${id}`);
+  }
 
   return (
-    <div className={styles.box}>
+    <div className={styles.box} onClick={handleClick} style={{ cursor: 'pointer' }}>
       <div className={styles.top}>
         <CategoryIcon category={category} size={34} />
         <div className={styles.info}>

--- a/src/features/temptation/components/temptationSearch/SearchProductItem.tsx
+++ b/src/features/temptation/components/temptationSearch/SearchProductItem.tsx
@@ -19,7 +19,7 @@ export const SearchProductItem = ({ product, keyword }: SearchProductItemProps) 
   }
 
   return (
-    <div className={styles.box} onClick={handleClick} style={{ cursor: 'pointer' }}>
+    <button type="button" className={styles.box} onClick={handleClick} aria-label={`${name} 상세 보기`}>
       <div className={styles.top}>
         <CategoryIcon category={category} size={34} />
         <div className={styles.info}>
@@ -28,6 +28,6 @@ export const SearchProductItem = ({ product, keyword }: SearchProductItemProps) 
         </div>
       </div>
       <p className={styles.time}>남은 대기 시간 {formatRemainingTime(time)}</p>
-    </div>
+    </button>
   );
 };

--- a/src/features/temptation/hooks/WishlistContext.ts
+++ b/src/features/temptation/hooks/WishlistContext.ts
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react';
+import type { useWishlist } from './useWishlist';
+
+type WishlistContextValue = ReturnType<typeof useWishlist>;
+
+export const WishlistContext = createContext<WishlistContextValue | null>(null);
+
+export const useWishlistContext = () => {
+  const ctx = useContext(WishlistContext);
+  if (!ctx) {
+    throw new Error('useWishlistContext는 WishlistProvider 내부에서만 사용할 수 있습니다.');
+  }
+  return ctx;
+};

--- a/src/features/temptation/hooks/WishlistProvider.tsx
+++ b/src/features/temptation/hooks/WishlistProvider.tsx
@@ -1,0 +1,12 @@
+import { Outlet } from 'react-router-dom';
+import { useWishlist } from '../hooks/useWishlist';
+import { WishlistContext } from './WishlistContext';
+
+export const WishlistProvider = () => {
+  const wishlist = useWishlist();
+  return (
+    <WishlistContext.Provider value={wishlist}>
+      <Outlet />
+    </WishlistContext.Provider>
+  );
+};

--- a/src/features/temptation/hooks/useProductDetail.ts
+++ b/src/features/temptation/hooks/useProductDetail.ts
@@ -1,0 +1,7 @@
+import { MOCK_PRODUCTS } from '../mockData';
+import type { Product } from '../types';
+
+// TODO: 백엔드 API 연동 시 실제 상품 단건 조회 API로 교체
+export const useProductDetail = (id: string): Product | undefined => {
+  return MOCK_PRODUCTS.find((p) => p.id === id);
+};

--- a/src/features/temptation/hooks/useWishlist.ts
+++ b/src/features/temptation/hooks/useWishlist.ts
@@ -16,10 +16,11 @@ const timeStringToDate = (time: typeof TIME_OPTIONS[number]): Date => {
   return new Date(Date.now() + hours * 60 * 60 * 1000);
 };
 
-export const useWishlist = (keyword: string = '') => {
+export const useWishlist = () => {
   const [products, setProducts] = useState<Product[]>(MOCK_PRODUCTS);
   const [filter, setFilter] = useState<FilterValue>('전체');
   const [sort, setSort] = useState<SortValue>('가나다순');
+  const [keyword, setKeyword] = useState('');
 
   const filteredProducts = useMemo(() => {
     let target = filter === '전체' ? products : products.filter((p) => p.category === filter);
@@ -49,6 +50,7 @@ export const useWishlist = (keyword: string = '') => {
       category: formData.category,
       link: formData.link,
       reason: formData.reason,
+      createdAt: new Date(),
     };
     setProducts((prev) => [...prev, newProduct]);
   };
@@ -56,6 +58,8 @@ export const useWishlist = (keyword: string = '') => {
   const categoriesToRender: Category[] = filter === '전체' ? [...CATEGORIES] : [filter];
 
   return {
+    keyword,
+    setKeyword,
     filter,
     setFilter,
     sort,

--- a/src/features/temptation/mockData.ts
+++ b/src/features/temptation/mockData.ts
@@ -4,10 +4,22 @@ const hoursFromNow = (h: number) => new Date(Date.now() + h * 60 * 60 * 1000);
 
 // 백엔드 연동 전까지 사용할 임시 데이터
 export const MOCK_PRODUCTS: Product[] = [
-  { id: '1', name: '스탠다드 유넥 반팔티', price: 21000, time: hoursFromNow(13), category: '패션' },
-  { id: '2', name: '와이드 데님 팬츠', price: 30000, time: hoursFromNow(48), category: '패션' },
-  { id: '3', name: '캔버스 크로스백', price: 45000, time: hoursFromNow(24), category: '패션' },
-  { id: '4', name: '생딸기 몽땅 요아정 (2인)', price: 14000, time: hoursFromNow(13), category: '카페/디저트' },
-  { id: '5', name: '두쫀쿠', price: 5000, time: hoursFromNow(24), category: '카페/디저트' },
-  { id: '6', name: '쏘내추럴 메이크업 세팅 픽서', price: 24000, time: hoursFromNow(72), category: '뷰티' },
+  { id: '1', name: '스탠다드 유넥 반팔티', price: 21000, time: hoursFromNow(13), createdAt: new Date(), category: '패션',
+    reason: '반팔티가 필요해서', link: 'https://black-up.kr/product/123451234123412341234123412341234'
+   },
+  { id: '2', name: '와이드 데님 팬츠', price: 30000, time: hoursFromNow(48), createdAt: new Date(), category: '패션',
+   },
+  { id: '3', name: '캔버스 크로스백', price: 45000, time: hoursFromNow(24), createdAt: new Date(), category: '패션' },
+  { id: '4', name: '생딸기 몽땅 요아정 (2인)', price: 14000, time: hoursFromNow(13), createdAt: new Date(), category: '카페/디저트',
+   },
+  { id: '5', name: '두쫀쿠', price: 5000, time: hoursFromNow(24), createdAt: new Date(), category: '카페/디저트' },
+  { id: '6', name: '쏘내추럴 메이크업 세팅 픽서', price: 24000, time: hoursFromNow(72), createdAt: new Date(), category: '뷰티' },
 ];
+
+// 백엔드 연동 시 실제 삭제 요청으로 교체 필요
+export const removeMockProduct = (id: string) => {
+  const index = MOCK_PRODUCTS.findIndex((p) => p.id === id);
+  if (index !== -1) {
+    MOCK_PRODUCTS.splice(index, 1);
+  }
+};

--- a/src/features/temptation/pages/TemptationInfo.module.css
+++ b/src/features/temptation/pages/TemptationInfo.module.css
@@ -1,0 +1,4 @@
+.wrapper {
+  padding: 16px;
+  padding-bottom: 100px;
+}

--- a/src/features/temptation/pages/TemptationInfo.tsx
+++ b/src/features/temptation/pages/TemptationInfo.tsx
@@ -1,0 +1,106 @@
+import { useNavigate, useParams } from 'react-router-dom';
+import { IoIosArrowBack } from 'react-icons/io';
+import { PiListBold } from 'react-icons/pi';
+import { IoNotifications } from 'react-icons/io5';
+import Header from '@/components/layout/Header';
+import { InfoHeader } from '../components/temptationInfo/InfoHeader';
+import { RemainingTime } from '../components/temptationInfo/RemainingTime';
+import { InfoBox } from '../components/temptationInfo/InfoBox';
+import { ActionButton } from '../components/temptationInfo/ActionButton';
+import { MOCK_PRODUCTS, removeMockProduct } from '../mockData';
+import styles from './TemptationInfo.module.css';
+import { ConfirmDialog } from '../components/ConfirmDialog';
+import { useState } from 'react';
+
+export default function TemptationInfo() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  
+  const product = MOCK_PRODUCTS.find((p) => p.id === id);
+
+  const [isGiveUpOpen, setIsGiveUpOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  
+  const handleBack = () => {
+    navigate('/temptation');
+  };
+
+  const handleEdit = () => {
+    console.log('수정하기 클릭');
+  };
+
+  const handleGiveUpOpen = () => {
+    setErrorMessage('');
+    setIsGiveUpOpen(true);
+  };
+
+  const handleGiveUpCancel = () => {
+    if (isSubmitting) return;
+    setIsGiveUpOpen(false);
+    setErrorMessage('');
+  };
+
+  const handleGiveUpConfirm = async () => {
+    if (!product) return;
+    setIsSubmitting(true);
+    setErrorMessage('');
+
+    try {
+      // 백엔드 연동 시 실제 삭제 요청으로 교체 필요
+      // 삭제 성공 시 참은 소비 기록에 반영하는 로직 추가 필요
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      removeMockProduct(product.id);
+      navigate('/temptation');
+    } catch {
+      setErrorMessage('처리하지 못했습니다. 다시 시도해 주세요.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!product) {
+    return <p>상품을 찾을 수 없습니다.</p>;
+  }
+
+  return (
+    <>
+      <Header
+        left={<button type="button" aria-label="로고">Logo</button>}
+        right={
+          <>
+            <button type="button" aria-label="알림"><IoNotifications /></button>
+            <button type="button" aria-label="메뉴 열기"><PiListBold /></button>
+          </>
+        }
+        subLeft={
+          <button type="button" aria-label="뒤로가기" onClick={handleBack}>
+            <IoIosArrowBack size={25} />
+          </button>
+        }
+        subMain={<InfoHeader category={product.category} name={product.name} />}
+      />
+      <div className={styles.wrapper}>
+        <RemainingTime deadline={product.time} createdAt={product.createdAt} />
+        <InfoBox
+          price={product.price}
+          reason={product.reason}
+          link={product.link}
+        />
+        <ActionButton onEdit={handleEdit} onGiveUp={handleGiveUpOpen} />
+      </div>
+
+      <ConfirmDialog
+        isOpen={isGiveUpOpen}
+        title="이 상품을 포기하시겠습니까?"
+        description="포기한 금액은 참은 소비 기록에 반영됩니다."
+        cancelText="취소"
+        confirmText="포기하기"
+        isLoading={isSubmitting}
+        errorMessage={errorMessage}
+        onCancel={handleGiveUpCancel}
+        onConfirm={handleGiveUpConfirm}
+      />
+    </>
+  );
+}

--- a/src/features/temptation/pages/TemptationInfo.tsx
+++ b/src/features/temptation/pages/TemptationInfo.tsx
@@ -7,16 +7,17 @@ import { InfoHeader } from '../components/temptationInfo/InfoHeader';
 import { RemainingTime } from '../components/temptationInfo/RemainingTime';
 import { InfoBox } from '../components/temptationInfo/InfoBox';
 import { ActionButton } from '../components/temptationInfo/ActionButton';
-import { MOCK_PRODUCTS, removeMockProduct } from '../mockData';
 import styles from './TemptationInfo.module.css';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import { useState } from 'react';
+import { useWishlistContext } from '../hooks/WishlistContext';
 
 export default function TemptationInfo() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { filteredProducts, handleDelete } = useWishlistContext();
   
-  const product = MOCK_PRODUCTS.find((p) => p.id === id);
+  const product = filteredProducts.find((p) => p.id === id);
 
   const [isGiveUpOpen, setIsGiveUpOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -49,7 +50,7 @@ export default function TemptationInfo() {
     try {
       // 백엔드 연동 시 실제 삭제 요청으로 교체 필요
       await new Promise((resolve) => setTimeout(resolve, 400));
-      removeMockProduct(product.id);
+      handleDelete(product.id);
       navigate('/temptation');
     } catch {
       setErrorMessage('처리하지 못했습니다. 다시 시도해 주세요.');

--- a/src/features/temptation/pages/TemptationInfo.tsx
+++ b/src/features/temptation/pages/TemptationInfo.tsx
@@ -48,7 +48,6 @@ export default function TemptationInfo() {
 
     try {
       // 백엔드 연동 시 실제 삭제 요청으로 교체 필요
-      // 삭제 성공 시 참은 소비 기록에 반영하는 로직 추가 필요
       await new Promise((resolve) => setTimeout(resolve, 400));
       removeMockProduct(product.id);
       navigate('/temptation');

--- a/src/features/temptation/pages/TemptationMain.tsx
+++ b/src/features/temptation/pages/TemptationMain.tsx
@@ -1,4 +1,4 @@
-import { useWishlist } from '../hooks/useWishlist';
+import { useWishlistContext } from '../hooks/WishlistContext';
 import { CategoryFilterTabs } from '../components/temptationMain/CategoryFilterBar';
 import { SortTabs } from '../components/temptationMain/SortBar';
 import { CategoryProductBox } from '../components/temptationMain/CategoryProductBox';
@@ -9,11 +9,7 @@ import { BottomAdd } from '../components/temptationAdd/ProductAdd';
 import { ProductForm } from '@/components/layout/ProductForm';
 import type { FormData as WishFormData } from '@/components/layout/ProductForm';
 
-interface TemptationMainProps {
-  keyword?: string;
-}
-
-export default function TemptationMain({ keyword = '' }: TemptationMainProps) {
+export default function TemptationMain() {
   const {
     filter,
     setFilter,
@@ -23,7 +19,7 @@ export default function TemptationMain({ keyword = '' }: TemptationMainProps) {
     categoriesToRender,
     handleDelete,
     handleAdd,
-  } = useWishlist(keyword);
+  } = useWishlistContext();
 
   const [isAddOpen, setIsAddOpen] = useState(false);
   const handleWishAdd = (data: WishFormData) => {

--- a/src/features/temptation/types.ts
+++ b/src/features/temptation/types.ts
@@ -10,7 +10,7 @@ export interface Product {
   category: Category;
   link?: string;
   reason?: string;
-  createdAt?: Date;
+  createdAt: Date;
 }
 
 export type FilterValue = '전체' | Category;

--- a/src/features/temptation/types.ts
+++ b/src/features/temptation/types.ts
@@ -10,6 +10,7 @@ export interface Product {
   category: Category;
   link?: string;
   reason?: string;
+  createdAt?: Date;
 }
 
 export type FilterValue = '전체' | Category;

--- a/src/features/temptation/utils/formatDetailTimer.ts
+++ b/src/features/temptation/utils/formatDetailTimer.ts
@@ -1,0 +1,17 @@
+export const formatDetailTimer = (deadline: Date | null): string => {
+  if (!deadline) return '--:--:--';
+
+  const diffMs = deadline.getTime() - Date.now();
+  if (diffMs <= 0) return '00:00:00';
+
+  const totalSeconds = Math.floor(diffMs / 1000);
+  const days = Math.floor(totalSeconds / 86400);
+  const hours = Math.floor((totalSeconds % 86400) / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const timePart = `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+
+  return days > 0 ? `${days}일 ${timePart}` : timePart;
+};

--- a/src/features/temptation/utils/remainPercent.ts
+++ b/src/features/temptation/utils/remainPercent.ts
@@ -1,0 +1,11 @@
+export const remainPercent = (deadline: Date | null, createdAt: Date | null): number => {
+  if (!deadline || !createdAt) return 0;
+
+  const total = deadline.getTime() - createdAt.getTime();
+  const elapsed = Date.now() - createdAt.getTime();
+
+  if (total <= 0) return 0;
+  const percent = (elapsed / total) * 100;
+
+  return Math.min(100, Math.max(0, percent));
+};

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -6,6 +6,8 @@ import RecordInterventionPage from '@/features/intervention/pages/RecordInterven
 import LoginPage from '@/pages/LoginPage'
 import SignUpPage from '@/pages/SignUpPage'
 import MyPagePage from '@/pages/MyPagePage'
+import Temptation from '@/features/temptation/Temptation'
+import TemptationInfo from '@/features/temptation/pages/TemptationInfo'
 
 const router = createBrowserRouter([
   { path: '/', element: <HomePage /> },
@@ -17,6 +19,9 @@ const router = createBrowserRouter([
   { path: '/record', element: <RecordMainPage /> },
   { path: '/record/:id', element: <RecordDetailPage /> },
   { path: '/record/intervention', element: <RecordInterventionPage /> },
+
+  { path: '/temptation', element: <Temptation />},
+  { path: '/temptation/:id', element: <TemptationInfo />},
 ])
 
 export default router

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom'
+import { WishlistProvider } from '@/features/temptation/hooks/WishlistProvider'
 import HomePage from '@/pages/HomePage'
 import RecordMainPage from '@/features/record/pages/RecordMainPage'
 import RecordDetailPage from '@/features/record/pages/RecordDetailPage'
@@ -20,8 +21,13 @@ const router = createBrowserRouter([
   { path: '/record/:id', element: <RecordDetailPage /> },
   { path: '/record/intervention', element: <RecordInterventionPage /> },
 
-  { path: '/temptation', element: <Temptation />},
-  { path: '/temptation/:id', element: <TemptationInfo />},
+  {
+    element: <WishlistProvider />,
+    children: [
+      { path: '/temptation', element: <Temptation />},
+      { path: '/temptation/:id', element: <TemptationInfo />},
+    ],
+  },
 ])
 
 export default router


### PR DESCRIPTION
## 📌 작업 내용

- 위시리스트 상품 클릭 시 확인할 수 있는 상세페이지 구현
- 유혹관리 내 페이지 라우팅(상품 클릭-상세페이지 이동) 구현
- 헤더 하단의 아이콘/카테고리/상품명 별도 컴포넌트로 분리 구현
- 상세페이지 내 남은 고민 시간 타이머/막대바 분리 구현
- 상세페이지 하단의 박스(가격/이유/링크) 분리 구현

## 📷 스크린 샷

- 전체 UI
<img width="738" height="1458" alt="스크린샷 2026-07-26 234323" src="https://github.com/user-attachments/assets/b0f9d89a-951c-4f72-8700-11ed124ffc1e" />

- 24시간 이상일 경우 일수 표기 & 막대바 채워지는 것 확인
<img width="692" height="156" alt="스크린샷 2026-07-26 235140" src="https://github.com/user-attachments/assets/205b9999-b585-4d4b-ae62-4e0f17079a3a" />

- 사고 싶은 이유&링크가 없을 경우
<img width="736" height="816" alt="스크린샷 2026-07-26 234349" src="https://github.com/user-attachments/assets/3056927d-2283-41b3-bc48-82bf240a734f" />

- '포기하기' 버튼 클릭 시 팝업
<img width="612" height="476" alt="스크린샷 2026-07-26 234405" src="https://github.com/user-attachments/assets/6d5c4b7f-78a0-401f-b77c-3bb061ebc9dc" />

## ⚠️ 참고 사항

- 피그마에 작성된 화면설계서 내용을 최대한 반영하여 개발했습니다 (남은 시간 표기, 가격 단위 등)
- 화면설계서 내용 중 '사고 싶은 이유에 입력한 줄바꿈을 유지하여 표시'가 있었으나, 실제 작성 폼은 <Input> 태그라서 줄바꿈이 불가한 것을 확인했습니다. 화면 개발과 함께 줄바꿈이 가능한 <textarea> 태그로 해당 부분 수정하였습니다.
<img width="678" height="472" alt="스크린샷 2026-07-26 234920" src="https://github.com/user-attachments/assets/8f3556ca-b783-4122-9ae4-f79d6b79e7d2" />

- 페이지 최하단 버튼(수정하기/포기하기)의 경우 추후 공통 컴포넌트로 개발 예정임을 확인했습니다. 현재는 임의로 코드 작성 후 UI 구성한 상태이며, 공통 컴포넌트 개발 후 수정하고자 합니다.
- '포기하기' 클릭 시 위시리스트에서 상품이 삭제되는 것은 확인했으나 소비 기록으로 저장되는 로직은 구현되지 않은 상태입니다.

## 🔗 관련 이슈

Closes #23 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 상품 목록/검색 결과 및 상세 페이지로의 이동을 추가했습니다.
  * 상세 페이지에 카테고리, 가격, 사유, 링크, 남은 시간을 표시하고, 링크 복사(성공/실패 안내) 및 포기하기 확인 대화상자를 제공합니다.
  * “수정하기/포기하기” 액션 버튼과 남은 시간 실시간 표시를 추가했습니다.
* **개선**
  * 사유 입력을 여러 줄 입력으로 변경하고, 입력/placeholder 및 UI 스타일을 정교하게 다듬었습니다.
  * 정보 표시 카드의 레이아웃과 타이포그래피를 개선했습니다.
* **유지보수**
  * 라우팅 관련 라이브러리 버전을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->