### PR TITLE
✨ [Feature] Screen Specification 반영 - 온보딩 2

### DIFF
--- a/src/pages/OnboardingGoalPage.module.css
+++ b/src/pages/OnboardingGoalPage.module.css
@@ -174,8 +174,18 @@
   flex-shrink: 0;
 }
 
+.inputWrap:focus-within {
+  border-color: #2f7f82;
+  box-shadow: 0 0 0 3px rgba(47, 127, 130, 0.15);
+}
+
 .inputWrapError {
   border-color: #ee5555;
+}
+
+.inputWrapError:focus-within {
+  border-color: #ee5555;
+  box-shadow: 0 0 0 3px rgba(238, 85, 85, 0.15);
 }
 
 .wonLabelActive {
@@ -228,6 +238,13 @@
   font-size: 12px;
   font-weight: 600;
   color: #2f7f82;
+}
+
+.purposeDesc {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: #7a9190;
+  line-height: 1.5;
 }
 
 .btnRow {

--- a/src/pages/OnboardingGoalPage.module.css
+++ b/src/pages/OnboardingGoalPage.module.css
@@ -1,0 +1,269 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  background: #fff;
+}
+
+.content {
+  flex: 1;
+  padding: 56px 28px 0;
+  overflow-y: auto;
+}
+
+/* 진행 점 */
+.dots {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.dotActive {
+  width: 24px;
+  height: 8px;
+  border-radius: 999px;
+  background: #2f7f82;
+  flex-shrink: 0;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #e0e0e0;
+  flex-shrink: 0;
+}
+
+/* 타이틀 */
+.title {
+  margin: 40px 0 0;
+  font-size: 30px;
+  font-weight: 700;
+  color: #1a2e2d;
+  line-height: 1.3;
+}
+
+.subtitle {
+  margin: 12px 0 0;
+  font-size: 14px;
+  color: #7a9190;
+  line-height: 1.6;
+}
+
+/* 선택 안내 */
+.labelRow {
+  margin-top: 28px;
+}
+
+.labelInner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 29px;
+}
+
+.label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #aaa;
+}
+
+.resetBtn {
+  font-size: 12px;
+  font-weight: 600;
+  color: #2f7f82;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+}
+
+.divider {
+  height: 3px;
+  background: #f0f0f0;
+  border-radius: 999px;
+  margin-top: 8px;
+}
+
+/* 목적 칩 */
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 44px;
+  padding: 0 19.5px;
+  border-radius: 999px;
+  border: 1.5px solid #e8e8e8;
+  background: #fafafa;
+  box-shadow: 0px 1px 1.5px rgba(0, 0, 0, 0.05);
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.chipSelected {
+  background: #2f7f82;
+  border-color: #2f7f82;
+}
+
+.chipSelected .chipLabel {
+  color: #fff;
+}
+
+.chipEmoji {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.chipLabel {
+  font-size: 14px;
+  font-weight: 600;
+  color: #444;
+  white-space: nowrap;
+}
+
+/* 월 목표 금액 섹션 */
+.amountSection {
+  margin-top: 28px;
+  padding-bottom: 32px;
+}
+
+.amountLabel {
+  margin: 0 0 10px;
+  font-size: 13px;
+  font-weight: 700;
+  color: #364153;
+}
+
+.inputWrap {
+  display: flex;
+  align-items: center;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 12px;
+  height: 52px;
+  padding: 0 16px;
+}
+
+.amountInput {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a2e2d;
+  text-align: right;
+  background: transparent;
+}
+
+.amountInput::placeholder {
+  color: #d1d5dc;
+  font-weight: 400;
+}
+
+.wonLabel {
+  font-size: 16px;
+  font-weight: 600;
+  color: #bbb;
+  margin-left: 6px;
+  flex-shrink: 0;
+}
+
+.inputWrapError {
+  border-color: #ee5555;
+}
+
+.wonLabelActive {
+  color: #1a2e2d;
+}
+
+.errorMsg {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: #ee5555;
+}
+
+.amountHint {
+  margin: 8px 0 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: #2f7f82;
+  text-align: right;
+}
+
+.saveError {
+  margin: 0 0 10px;
+  font-size: 13px;
+  color: #ee5555;
+  text-align: center;
+}
+
+/* 하단 버튼 영역 */
+.bottom {
+  padding: 12px 24px 32px;
+  background: #fff;
+}
+
+.selectedTags {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 30px;
+  padding: 0 12px;
+  border-radius: 999px;
+  background: #f0fafa;
+  border: 1px solid #c8e6e6;
+  font-size: 12px;
+  font-weight: 600;
+  color: #2f7f82;
+}
+
+.btnRow {
+  display: flex;
+  gap: 10px;
+}
+
+.prevBtn {
+  height: 54px;
+  width: 90px;
+  flex-shrink: 0;
+  border-radius: 16px;
+  border: none;
+  background: #f0f0f0;
+  color: #888;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.nextBtn {
+  flex: 1;
+  height: 54px;
+  border-radius: 16px;
+  border: none;
+  background: #f0f0f0;
+  color: #bbb;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: default;
+  transition: background 0.2s, color 0.2s;
+}
+
+.nextBtnActive {
+  background: #2f7f82;
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0px 4px 12px rgba(47, 127, 130, 0.3);
+}

--- a/src/pages/OnboardingGoalPage.tsx
+++ b/src/pages/OnboardingGoalPage.tsx
@@ -44,7 +44,7 @@ export default function OnboardingGoalPage() {
     const raw = e.target.value.replace(/[^0-9]/g, '')
     setSaveError('')
     if (raw === '') { setAmountInput(''); return }
-    if (Number(raw) > MAX_AMOUNT) return
+    if (Number(raw) > MAX_AMOUNT) setAmountTouched(true)
     setAmountInput(Number(raw).toLocaleString('ko-KR'))
   }
 

--- a/src/pages/OnboardingGoalPage.tsx
+++ b/src/pages/OnboardingGoalPage.tsx
@@ -3,15 +3,15 @@ import { useNavigate } from 'react-router-dom'
 import styles from './OnboardingGoalPage.module.css'
 
 const PURPOSES = [
-  { id: 'invest', emoji: '📊', label: '투자' },
-  { id: 'travel', emoji: '✈️', label: '여행' },
-  { id: 'hobby', emoji: '🎯', label: '취미' },
-  { id: 'car', emoji: '🚗', label: '자동차' },
-  { id: 'lumpsum', emoji: '💰', label: '목돈 마련' },
-  { id: 'house', emoji: '🏠', label: '내 집 마련' },
-  { id: 'retire', emoji: '👴', label: '노후 준비' },
-  { id: 'selfdev', emoji: '📖', label: '자기계발' },
-  { id: 'etc', emoji: '➕', label: '기타' },
+  { id: 'invest', emoji: '📊', label: '투자', description: '미래를 위한 투자 습관을 만들어요.' },
+  { id: 'travel', emoji: '✈️', label: '여행', description: '꿈꾸는 여행을 위해 차곡차곡 모아요.' },
+  { id: 'hobby', emoji: '🎯', label: '취미', description: '좋아하는 취미 생활을 마음껏 즐겨요.' },
+  { id: 'car', emoji: '🚗', label: '자동차', description: '내 차 마련을 위해 저축해요.' },
+  { id: 'lumpsum', emoji: '💰', label: '목돈 마련', description: '목돈을 만들어 재정적 안정을 높여요.' },
+  { id: 'house', emoji: '🏠', label: '내 집 마련', description: '내 집 마련의 꿈을 향해 나아가요.' },
+  { id: 'retire', emoji: '👴', label: '노후 준비', description: '편안한 노후를 위해 미리 준비해요.' },
+  { id: 'selfdev', emoji: '📖', label: '자기계발', description: '나에게 투자하는 가장 가치 있는 소비예요.' },
+  { id: 'etc', emoji: '➕', label: '기타', description: '나만의 목표를 향해 저축해요.' },
 ]
 
 const MIN_AMOUNT = 1_000
@@ -54,7 +54,7 @@ export default function OnboardingGoalPage() {
     setSaving(true)
     setSaveError('')
     try {
-      // TODO: API 호출 - 1·2단계 설정값 저장
+      // TODO: API 호출 - 1·2단계 설정값 저장 (selectedId, amount 전달)
       await Promise.resolve()
       navigate('/onboarding/step3')
     } catch {
@@ -99,6 +99,7 @@ export default function OnboardingGoalPage() {
             <button
               key={id}
               className={`${styles.chip} ${selectedId === id ? styles.chipSelected : ''}`}
+              aria-pressed={selectedId === id}
               onClick={() => setSelectedId(prev => prev === id ? null : id)}
             >
               <span className={styles.chipEmoji}>{emoji}</span>
@@ -109,9 +110,10 @@ export default function OnboardingGoalPage() {
 
         {/* 월 목표 금액 */}
         <div className={styles.amountSection}>
-          <p className={styles.amountLabel}>월 목표 금액</p>
+          <label htmlFor="amount-input" className={styles.amountLabel}>월 목표 금액</label>
           <div className={`${styles.inputWrap} ${amountError ? styles.inputWrapError : ''}`}>
             <input
+              id="amount-input"
               className={styles.amountInput}
               type="text"
               inputMode="numeric"
@@ -119,11 +121,13 @@ export default function OnboardingGoalPage() {
               onChange={handleAmountChange}
               onBlur={() => setAmountTouched(true)}
               placeholder="0"
+              aria-invalid={!!amountError}
+              aria-describedby={amountError ? 'amount-error' : undefined}
             />
             <span className={`${styles.wonLabel} ${amountInput ? styles.wonLabelActive : ''}`}>원</span>
           </div>
           {amountError ? (
-            <p className={styles.errorMsg}>{amountError}</p>
+            <p id="amount-error" className={styles.errorMsg}>{amountError}</p>
           ) : isAmountValid ? (
             <p className={styles.amountHint}>월 {amount.toLocaleString('ko-KR')}원 목표</p>
           ) : null}
@@ -136,6 +140,7 @@ export default function OnboardingGoalPage() {
         {selectedPurpose && !saveError && (
           <div className={styles.selectedTags}>
             <span className={styles.tag}>{selectedPurpose.emoji} {selectedPurpose.label}</span>
+            <p className={styles.purposeDesc}>{selectedPurpose.description}</p>
           </div>
         )}
         <div className={styles.btnRow}>
@@ -143,6 +148,7 @@ export default function OnboardingGoalPage() {
           <button
             className={`${styles.nextBtn} ${isActive && !saving ? styles.nextBtnActive : ''}`}
             onClick={handleNext}
+            disabled={!isActive || saving}
           >
             {saving ? '저장 중...' : '다음'}
           </button>

--- a/src/pages/OnboardingGoalPage.tsx
+++ b/src/pages/OnboardingGoalPage.tsx
@@ -1,0 +1,153 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import styles from './OnboardingGoalPage.module.css'
+
+const PURPOSES = [
+  { id: 'invest', emoji: '📊', label: '투자' },
+  { id: 'travel', emoji: '✈️', label: '여행' },
+  { id: 'hobby', emoji: '🎯', label: '취미' },
+  { id: 'car', emoji: '🚗', label: '자동차' },
+  { id: 'lumpsum', emoji: '💰', label: '목돈 마련' },
+  { id: 'house', emoji: '🏠', label: '내 집 마련' },
+  { id: 'retire', emoji: '👴', label: '노후 준비' },
+  { id: 'selfdev', emoji: '📖', label: '자기계발' },
+  { id: 'etc', emoji: '➕', label: '기타' },
+]
+
+const MIN_AMOUNT = 1_000
+const MAX_AMOUNT = 1_000_000_000
+
+function getAmountError(raw: string, value: number): string {
+  if (raw === '') return '월 목표 금액을 입력해주세요.'
+  if (value < MIN_AMOUNT) return '월 목표 금액은 1,000원 이상 입력해주세요.'
+  if (value > MAX_AMOUNT) return '월 목표 금액은 10억 원 이하로 입력해주세요.'
+  return ''
+}
+
+export default function OnboardingGoalPage() {
+  const navigate = useNavigate()
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [amountInput, setAmountInput] = useState('')
+  const [amountTouched, setAmountTouched] = useState(false)
+  const [saveError, setSaveError] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  const rawAmount = amountInput.replace(/,/g, '')
+  const amount = rawAmount === '' ? 0 : Number(rawAmount)
+  const amountError = amountTouched ? getAmountError(rawAmount, amount) : ''
+  const isAmountValid = rawAmount !== '' && amount >= MIN_AMOUNT && amount <= MAX_AMOUNT
+  const isActive = selectedId !== null && isAmountValid
+
+  const selectedPurpose = PURPOSES.find(p => p.id === selectedId)
+
+  const handleAmountChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.replace(/[^0-9]/g, '')
+    setSaveError('')
+    if (raw === '') { setAmountInput(''); return }
+    if (Number(raw) > MAX_AMOUNT) return
+    setAmountInput(Number(raw).toLocaleString('ko-KR'))
+  }
+
+  const handleNext = async () => {
+    setAmountTouched(true)
+    if (!isActive || saving) return
+    setSaving(true)
+    setSaveError('')
+    try {
+      // TODO: API 호출 - 1·2단계 설정값 저장
+      await Promise.resolve()
+      navigate('/onboarding/step3')
+    } catch {
+      setSaveError('설정을 저장하지 못했습니다. 다시 시도해주세요.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.content}>
+        {/* 진행 점 */}
+        <div className={styles.dots}>
+          <div className={styles.dot} />
+          <div className={styles.dotActive} />
+          <div className={styles.dot} />
+        </div>
+
+        {/* 타이틀 */}
+        <h1 className={styles.title}>
+          저축 / 절약 목적을<br />알려주세요
+        </h1>
+        <p className={styles.subtitle}>목표 금액과 저축 / 절약 목적을 함께 설정해보세요.</p>
+
+        {/* 선택 안내 */}
+        <div className={styles.labelRow}>
+          <div className={styles.labelInner}>
+            <span className={styles.label}>
+              {selectedId ? '선택 완료' : '1개 이상 선택해주세요'}
+            </span>
+            {selectedId && (
+              <button className={styles.resetBtn} onClick={() => setSelectedId(null)}>초기화</button>
+            )}
+          </div>
+          <div className={styles.divider} />
+        </div>
+
+        {/* 목적 칩 */}
+        <div className={styles.chips}>
+          {PURPOSES.map(({ id, emoji, label }) => (
+            <button
+              key={id}
+              className={`${styles.chip} ${selectedId === id ? styles.chipSelected : ''}`}
+              onClick={() => setSelectedId(prev => prev === id ? null : id)}
+            >
+              <span className={styles.chipEmoji}>{emoji}</span>
+              <span className={styles.chipLabel}>{label}</span>
+            </button>
+          ))}
+        </div>
+
+        {/* 월 목표 금액 */}
+        <div className={styles.amountSection}>
+          <p className={styles.amountLabel}>월 목표 금액</p>
+          <div className={`${styles.inputWrap} ${amountError ? styles.inputWrapError : ''}`}>
+            <input
+              className={styles.amountInput}
+              type="text"
+              inputMode="numeric"
+              value={amountInput}
+              onChange={handleAmountChange}
+              onBlur={() => setAmountTouched(true)}
+              placeholder="0"
+            />
+            <span className={`${styles.wonLabel} ${amountInput ? styles.wonLabelActive : ''}`}>원</span>
+          </div>
+          {amountError ? (
+            <p className={styles.errorMsg}>{amountError}</p>
+          ) : isAmountValid ? (
+            <p className={styles.amountHint}>월 {amount.toLocaleString('ko-KR')}원 목표</p>
+          ) : null}
+        </div>
+      </div>
+
+      {/* 하단 버튼 */}
+      <div className={styles.bottom}>
+        {saveError && <p className={styles.saveError}>{saveError}</p>}
+        {selectedPurpose && !saveError && (
+          <div className={styles.selectedTags}>
+            <span className={styles.tag}>{selectedPurpose.emoji} {selectedPurpose.label}</span>
+          </div>
+        )}
+        <div className={styles.btnRow}>
+          <button className={styles.prevBtn} onClick={() => navigate(-1)}>이전</button>
+          <button
+            className={`${styles.nextBtn} ${isActive && !saving ? styles.nextBtnActive : ''}`}
+            onClick={handleNext}
+          >
+            {saving ? '저장 중...' : '다음'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -11,6 +11,7 @@ import MyPagePage from '@/pages/MyPagePage'
 import GoalAmountPage from '@/pages/GoalAmountPage'
 import ProfilePage from '@/pages/ProfilePage'
 import OnboardingInterestPage from '@/pages/OnboardingInterestPage'
+import OnboardingGoalPage from '@/pages/OnboardingGoalPage'
 
 const router = createBrowserRouter([
   { path: '/', element: <HomePage /> },
@@ -22,6 +23,7 @@ const router = createBrowserRouter([
   {path: '/profile', element: <ProfilePage />,},
 
   { path: '/onboarding', element: <OnboardingInterestPage /> },
+  { path: '/onboarding/step2', element: <OnboardingGoalPage /> },
 
   { path: '/record', element: <RecordMainPage /> },
   { path: '/record/:id', element: <RecordDetailPage /> },

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,34 +1,61 @@
 import { createBrowserRouter } from 'react-router-dom'
+import AppLayout from '@/components/layout/AppLayout'
+import { WishlistProvider } from '@/features/temptation/hooks/WishlistProvider'
 import HomePage from '@/pages/HomePage'
 import NotificationPage from '@/pages/NotificationPage'
 import RecordMainPage from '@/features/record/pages/RecordMainPage'
 import RecordDetailPage from '@/features/record/pages/RecordDetailPage'
+import RecordCreatePage from '@/features/record/pages/RecordCreatePage'
 import RecordInterventionPage from '@/features/intervention/pages/RecordInterventionPage'
 import RiskResultPage from '@/features/intervention/pages/RiskResultPage'
 import LoginPage from '@/pages/LoginPage'
 import SignUpPage from '@/pages/SignUpPage'
 import MyPagePage from '@/pages/MyPagePage'
+import Temptation from '@/features/temptation/Temptation'
+import TemptationInfo from '@/features/temptation/pages/TemptationInfo'
 import GoalAmountPage from '@/pages/GoalAmountPage'
 import ProfilePage from '@/pages/ProfilePage'
+import TemptationEdit from '@/features/temptation/pages/TemptationEdit'
+import ChangeEmailPage from '@/pages/ChangeEmailPage'
+import ChangePasswordPage from '@/pages/ChangePasswordPage'
+import WithdrawPage from '@/pages/WithdrawPage'
 import OnboardingInterestPage from '@/pages/OnboardingInterestPage'
 import OnboardingGoalPage from '@/pages/OnboardingGoalPage'
 
 const router = createBrowserRouter([
-  { path: '/', element: <HomePage /> },
-  { path: '/login', element: <LoginPage /> },
-  { path: '/signup', element: <SignUpPage /> },
-  { path: '/mypage', element: <MyPagePage /> }, 
-  {path: '/goal-amount', element: <GoalAmountPage /> },
-  { path: '/notification', element: <NotificationPage /> },
-  {path: '/profile', element: <ProfilePage />,},
-
-  { path: '/onboarding', element: <OnboardingInterestPage /> },
-  { path: '/onboarding/step2', element: <OnboardingGoalPage /> },
-
-  { path: '/record', element: <RecordMainPage /> },
-  { path: '/record/:id', element: <RecordDetailPage /> },
-  { path: '/record/intervention', element: <RecordInterventionPage /> },
-  { path: '/record/intervention/result', element: <RiskResultPage /> },
+  {
+    element: <AppLayout />,
+    children: [
+      { path: '/', element: <HomePage /> },
+      { path: '/login', element: <LoginPage /> },
+      { path: '/signup', element: <SignUpPage /> },
+      { path: '/mypage', element: <MyPagePage /> },
+      { path: '/goal-amount', element: <GoalAmountPage /> },
+      { path: '/notification', element: <NotificationPage /> },
+      { path: '/profile', element: <ProfilePage /> },
+      { path: '/changeemail', element: <ChangeEmailPage /> },
+      { path: '/changepassword', element: <ChangePasswordPage /> },
+      { path: '/withdraw', element: <WithdrawPage /> },
+      { path: '/onboarding', element: <OnboardingInterestPage /> },
+      { path: '/onboarding/step2', element: <OnboardingGoalPage /> },
+      { path: '/record', element: <RecordMainPage /> },
+      { path: '/record/new', element: <RecordCreatePage /> },
+      { path: '/record/:id', element: <RecordDetailPage /> },
+      { path: '/record/intervention', element: <RecordInterventionPage /> },
+      {
+        path: '/record/intervention/result',
+        element: <RiskResultPage />,
+      },
+      {
+        element: <WishlistProvider />,
+        children: [
+          { path: '/temptation', element: <Temptation /> },
+          { path: '/temptation/:id', element: <TemptationInfo /> },
+          { path: '/temptation/:id/edit', element: <TemptationEdit /> },
+        ],
+      },
+    ],
+  },
 ])
 
 export default router


### PR DESCRIPTION
## 📌 작업 내용

- 목적 항목은 단일 선택만 가능하도록 구현 (기존 선택 항목 클릭 시 다른 항목으로 교체)
- 선택된 항목 칩 형태로 표시, 초기화 버튼으로 선택 해제 기능 추가
- 월 목표 금액 입력 필드 구현
- 입력 시 3자리 단위 콤마 포맷 적용 (예: 500,000)
- 입력값 우측에 단위(원) 고정 표시
- 입력 가능 범위 최소 1,000원 ~ 최대 1,000,000,000원으로 제한, 범위 벗어날 시 안내 문구 노출
- 목적 1개 선택 + 목표 금액 입력 완료 시 "다음" 버튼 활성화
- 선택된 목적에 따른 하단 안내 문구(월 500,000원 목표) 표시
- "이전" 버튼으로 이전 단계 이동 처리

## 📷 스크린 샷

<img width="352" height="737" alt="image" src="https://github.com/user-attachments/assets/6902335c-c247-4198-8e4e-e227870fa612" />

## ⚠️ 참고 사항

- 온보딩1 -> 온보딩2 -> 온보딩3 순으로 머지해야합니다!

## 🔗 관련 이슈

Closes #71 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 온보딩 과정에 저축 목표 설정 단계가 추가되었습니다.
  * 저축 목적을 선택하고 월 목표 금액을 입력할 수 있습니다.
  * 목표 금액은 1,000원 이상 10억 원 이하로 검증되며, 입력 오류가 표시됩니다.
  * 유효한 정보를 저장하면 다음 온보딩 단계로 이동합니다.
  * 저장 실패 안내와 이전 단계 이동을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->