### PR TITLE
✨ [Feature] Screen Specification 반영 - 온보딩 3

### DIFF
--- a/src/pages/OnboardingCompletePage.module.css
+++ b/src/pages/OnboardingCompletePage.module.css
@@ -1,0 +1,142 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  background: #fff;
+}
+
+.content {
+  flex: 1;
+  padding: 56px 28px 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* 진행 점 */
+.dots {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.dotActive {
+  width: 24px;
+  height: 8px;
+  border-radius: 999px;
+  background: #286a6d;
+  flex-shrink: 0;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #e0e0e0;
+  flex-shrink: 0;
+}
+
+/* 중앙 콘텐츠 */
+.centerSection {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 48px;
+  padding-bottom: 32px;
+}
+
+.emojiWrap {
+  font-size: 56px;
+  line-height: 1;
+  margin-bottom: 24px;
+  filter: drop-shadow(0px 4px 12px rgba(0, 0, 0, 0.08));
+}
+
+.badge {
+  background: #e1f5ee;
+  color: #186251;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 6px 16px;
+  border-radius: 999px;
+  margin-bottom: 20px;
+}
+
+.title {
+  margin: 0 0 12px;
+  font-size: 28px;
+  font-weight: 700;
+  color: #243130;
+  text-align: center;
+  line-height: 1.375;
+}
+
+.subtitle {
+  margin: 0 0 40px;
+  font-size: 14px;
+  color: #7a9190;
+  text-align: center;
+  line-height: 1.625;
+}
+
+/* 설정 요약 카드 */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  width: 100%;
+}
+
+.card {
+  background: #f7fbfa;
+  border: 1px solid #e0eeee;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 17px 9px;
+}
+
+.cardEmoji {
+  font-size: 24px;
+  line-height: 1;
+}
+
+.cardLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: #aaa;
+  white-space: nowrap;
+}
+
+.cardValue {
+  font-size: 12px;
+  font-weight: 700;
+  color: #243130;
+  text-align: center;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: keep-all;
+  line-height: 1.4;
+}
+
+/* 하단 버튼 */
+.bottom {
+  padding: 32px 24px 40px;
+}
+
+.homeBtn {
+  width: 100%;
+  height: 54px;
+  border-radius: 16px;
+  border: none;
+  background: linear-gradient(171deg, #2f7f82 0%, #3a9699 100%);
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0px 6px 10px rgba(47, 127, 130, 0.4);
+}

--- a/src/pages/OnboardingCompletePage.tsx
+++ b/src/pages/OnboardingCompletePage.tsx
@@ -1,0 +1,76 @@
+import { useNavigate, useLocation } from 'react-router-dom'
+import styles from './OnboardingCompletePage.module.css'
+
+interface OnboardingState {
+  interests: { emoji: string; label: string }[]
+  purpose: string
+  purposeEmoji: string
+  amount: number
+}
+
+export default function OnboardingCompletePage() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const {
+    interests = [],
+    purpose = '',
+    purposeEmoji = '➕',
+    amount = 0,
+  } = (location.state ?? {}) as Partial<OnboardingState>
+
+  const interestsText = interests.map(i => i.label).join(' · ') || '-'
+
+  const handleHome = () => {
+    localStorage.setItem('onboardingComplete', 'true')
+    navigate('/')
+  }
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.content}>
+        {/* 진행 점 */}
+        <div className={styles.dots}>
+          <div className={styles.dot} />
+          <div className={styles.dot} />
+          <div className={styles.dotActive} />
+        </div>
+
+        <div className={styles.centerSection}>
+          <div className={styles.emojiWrap}>👋</div>
+
+          <div className={styles.badge}>설정 완료</div>
+
+          <h1 className={styles.title}>준비 완료됐어요!</h1>
+
+          <p className={styles.subtitle}>
+            즐거운 소비관리를<br />지금 시작해보세요.
+          </p>
+
+          {/* 설정 요약 카드 */}
+          <div className={styles.cards}>
+            <div className={styles.card}>
+              <span className={styles.cardEmoji}>🎯</span>
+              <span className={styles.cardLabel}>월 목표</span>
+              <span className={styles.cardValue}>{amount.toLocaleString('ko-KR')}원</span>
+            </div>
+            <div className={styles.card}>
+              <span className={styles.cardEmoji}>📊</span>
+              <span className={styles.cardLabel}>관심사</span>
+              <span className={styles.cardValue}>{interestsText}</span>
+            </div>
+            <div className={styles.card}>
+              <span className={styles.cardEmoji}>{purposeEmoji}</span>
+              <span className={styles.cardLabel}>저축 목적</span>
+              <span className={styles.cardValue}>{purpose || '-'}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 홈으로 가기 버튼 */}
+      <div className={styles.bottom}>
+        <button className={styles.homeBtn} onClick={handleHome}>홈으로 가기</button>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/OnboardingGoalPage.tsx
+++ b/src/pages/OnboardingGoalPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import styles from './OnboardingGoalPage.module.css'
 
 const PURPOSES = [
@@ -26,6 +26,9 @@ function getAmountError(raw: string, value: number): string {
 
 export default function OnboardingGoalPage() {
   const navigate = useNavigate()
+  const location = useLocation()
+  const step1State = (location.state ?? {}) as { interests?: { emoji: string; label: string }[] }
+
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [amountInput, setAmountInput] = useState('')
   const [amountTouched, setAmountTouched] = useState(false)
@@ -56,7 +59,14 @@ export default function OnboardingGoalPage() {
     try {
       // TODO: API 호출 - 1·2단계 설정값 저장
       await Promise.resolve()
-      navigate('/onboarding/step3')
+      navigate('/onboarding/step3', {
+        state: {
+          interests: step1State.interests ?? [],
+          purpose: selectedPurpose?.label ?? '',
+          purposeEmoji: selectedPurpose?.emoji ?? '',
+          amount,
+        },
+      })
     } catch {
       setSaveError('설정을 저장하지 못했습니다. 다시 시도해주세요.')
     } finally {

--- a/src/pages/OnboardingInterestPage.tsx
+++ b/src/pages/OnboardingInterestPage.tsx
@@ -48,8 +48,9 @@ export default function OnboardingInterestPage() {
 
   const handleNext = () => {
     if (!hasSelected) return
-    // TODO: 선택값 전달 후 2단계로 이동
-    navigate('/onboarding/step2')
+    navigate('/onboarding/step2', {
+      state: { interests: selectedList.map(c => ({ emoji: c.emoji, label: c.label })) },
+    })
   }
 
   return (

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -12,6 +12,7 @@ import GoalAmountPage from '@/pages/GoalAmountPage'
 import ProfilePage from '@/pages/ProfilePage'
 import OnboardingInterestPage from '@/pages/OnboardingInterestPage'
 import OnboardingGoalPage from '@/pages/OnboardingGoalPage'
+import OnboardingCompletePage from '@/pages/OnboardingCompletePage'
 
 const router = createBrowserRouter([
   { path: '/', element: <HomePage /> },
@@ -24,6 +25,7 @@ const router = createBrowserRouter([
 
   { path: '/onboarding', element: <OnboardingInterestPage /> },
   { path: '/onboarding/step2', element: <OnboardingGoalPage /> },
+  { path: '/onboarding/step3', element: <OnboardingCompletePage /> },
 
   { path: '/record', element: <RecordMainPage /> },
   { path: '/record/:id', element: <RecordDetailPage /> },


### PR DESCRIPTION
## 📌 작업 내용

- "설정 완료" 배지 + "준비 완료됐어요!" 타이틀, "즐거운 소비관리를 지금 시작해보세요" 서브 문구 표시
- (👋) 아이콘 적용
- 하단에 "홈으로 가기" 버튼 배치, 클릭 시 홈 화면으로 이동 처리

## 📷 스크린 샷

<img width="352" height="662" alt="image" src="https://github.com/user-attachments/assets/1db2033f-65a7-434e-8b01-83807408f1a4" />

## ⚠️ 참고 사항

- 온보딩1 -> 온보딩2 -> 온보딩3 순으로 머지해야합니다!

## 🔗 관련 이슈

Closes #72 
