### PR TITLE
♻️ [Refactor] 소비 상세 page ui 수정 반영

### DIFF
--- a/src/features/record/pages/RecordDetailPage.module.css
+++ b/src/features/record/pages/RecordDetailPage.module.css
@@ -1,9 +1,31 @@
 .summary {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
   margin-top: 19px;
-  padding-bottom: 40px;
+  padding-bottom: 24px;
+}
+
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.categoryBadge {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  height: 22px;
+  padding: 0 8px;
+  border-radius: 11px;
+  border: 1px solid var(--color-main-500, #2f7f82);
+  font-family: Pretendard;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--color-main-500, #2f7f82);
+  white-space: nowrap;
 }
 
 .title {
@@ -14,6 +36,12 @@
   font-weight: 500;
   line-height: normal;
   color: var(--color-gray-300, #5b6b6a);
+}
+
+.amountRow {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
 }
 
 .amount {
@@ -31,6 +59,14 @@
   text-decoration: line-through;
 }
 
+.date {
+  margin: 0;
+  font-family: Pretendard;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-gray-300, #5b6b6a);
+}
+
 .content {
   display: flex;
   flex-direction: column;
@@ -40,14 +76,6 @@
 .section {
   display: flex;
   flex-direction: column;
-}
-
-.categorySection {
-  margin-bottom: 24px;
-}
-
-.categorySection .sectionLabel {
-  margin-bottom: 8px;
 }
 
 .reasonSection .sectionLabel {
@@ -63,35 +91,6 @@
   font-weight: 600;
   line-height: normal;
   color: var(--color-gray-300, #5b6b6a);
-}
-
-.chipGroup {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.chip {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 28px;
-  padding: 0 8px;
-  border-radius: 14px;
-  border: 1px solid var(--color-main-500, #2f7f82);
-  font-family: Pretendard;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--color-main-500, #2f7f82);
-  background: var(--color-text-white, #fefefe);
-  white-space: nowrap;
-  cursor: pointer;
-  transition: 0.2s ease;
-}
-
-.chipSelected {
-  color: var(--color-text-white, #fefefe);
-  background: var(--color-main-500, #2f7f82);
 }
 
 .reason {

--- a/src/features/record/pages/RecordDetailPage.tsx
+++ b/src/features/record/pages/RecordDetailPage.tsx
@@ -1,12 +1,21 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { IoChevronBack, IoNotifications, IoPencilOutline } from 'react-icons/io5'
 import { PiListBold } from 'react-icons/pi'
 import Header from '@/components/layout/Header'
 import RecentSpendingList from '@/features/intervention/components/RecentSpendingList'
 import { MOCK_RECORDS } from '@/features/record/mockRecords'
-import { CATEGORIES } from '@/constants/product'
 import styles from './RecordDetailPage.module.css'
+
+// 목데이터의 날짜가 "2026년 4월 17일" 형식이라 상세 화면 표기(YYYY.MM.DD)로 변환합니다.
+// API 연결 시 서버에서 포맷된 날짜를 받도록 수정 예정입니다.
+function formatDateCompact(dateLabel: string) {
+  const match = dateLabel.match(/(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일/)
+  if (!match) return dateLabel
+
+  const [, year, month, day] = match
+  return `${year}.${month.padStart(2, '0')}.${day.padStart(2, '0')}`
+}
 
 export default function RecordDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -20,16 +29,14 @@ export default function RecordDetailPage() {
     }
   }, [record, navigate])
 
-  const [selectedCategory, setSelectedCategory] = useState(record?.category)
-
   if (!record) return null
 
   const recentRecords = MOCK_RECORDS.filter(
-    (item) => item.category === selectedCategory && item.id !== record.id,
+    (item) => item.category === record.category && item.id !== record.id,
   )
 
   return (
-    <div key={record.id}>
+    <div>
       <Header
         left={
           <button type="button" aria-label="로고">
@@ -59,31 +66,22 @@ export default function RecordDetailPage() {
         }
         subMain={
           <div className={styles.summary}>
-            <p className={styles.title}>{record.title}</p>
-            <p className={`${styles.amount} ${record.type === 'consume' ? styles.consume : ''}`}>
-              {record.type === 'saved' ? '+' : '-'} {record.amount.toLocaleString('ko-KR')} 원
-            </p>
+            <div className={styles.titleRow}>
+              <span className={styles.categoryBadge}>{record.category}</span>
+              <p className={styles.title}>{record.title}</p>
+            </div>
+
+            <div className={styles.amountRow}>
+              <p className={`${styles.amount} ${record.type === 'consume' ? styles.consume : ''}`}>
+                {record.type === 'saved' ? '+' : '-'} {record.amount.toLocaleString('ko-KR')} 원
+              </p>
+              <p className={styles.date}>{formatDateCompact(record.date)}</p>
+            </div>
           </div>
         }
       />
 
       <div className={styles.content}>
-        <section className={`${styles.section} ${styles.categorySection}`}>
-          <h2 className={styles.sectionLabel}>카테고리</h2>
-          <div className={styles.chipGroup}>
-            {CATEGORIES.map((category) => (
-              <button
-                key={category}
-                type="button"
-                className={`${styles.chip} ${category === selectedCategory ? styles.chipSelected : ''}`}
-                onClick={() => setSelectedCategory(category)}
-              >
-                {category}
-              </button>
-            ))}
-          </div>
-        </section>
-
         {record.reason && (
           <section className={`${styles.section} ${styles.reasonSection}`}>
             <h2 className={styles.sectionLabel}>사고 싶은 이유</h2>


### PR DESCRIPTION
## 📌 작업 내용
- 소비 상세 화면 헤더에 카테고리 배지를 추가하고, 기존에 하단에 있던 카테고리 선택 칩 그리드(9개) 섹션은 삭제
- 헤더 요약 영역에 소비 날짜 추가 (`YYYY.MM.DD` 형식)
- "최근 해당 카테고리 소비" 리스트가 칩 선택 대신 레코드 자체의 카테고리를 기준으로 계산되도록 단순화
</br>

## 📷 스크린 샷
</br>

## ⚠️ 참고 사항
- 목데이터의 날짜가 "2026년 4월 17일" 형식이라 상세 화면 표기용으로 파싱해서 변환하는 함수를 추가했습니다. API 연결 시 서버에서 포맷된 날짜를 바로 받도록 수정 예정입니다
- 카테고리 칩 선택 UI 삭제로 인해 카테고리 수정 기능은 더 이상 이 화면에서 제공하지 않습니다 (헤더 우측 상단 수정 아이콘으로 추후 편집 기능 구현 예정)
</br>

## 🔗 관련 이슈
Closes #68



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 기록 상세 화면에 카테고리 배지, 금액, 날짜 정보가 표시됩니다.
  * 날짜가 `YYYY.MM.DD` 형식으로 표시됩니다.

* **개선**
  * 기록의 원래 카테고리를 보여주도록 변경했습니다.
  * 카테고리 선택 UI를 제거하고 상세 정보 레이아웃과 스타일을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->