### PR TITLE
✨ [Feature] 소비 기록 목록/상세 조회 API 연동

### DIFF
--- a/src/features/record/api/consumptionRecordApi.test.ts
+++ b/src/features/record/api/consumptionRecordApi.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest'
+import client from '@/api/client'
+import { consumptionRecordApi } from './consumptionRecordApi'
+
+vi.mock('@/api/client', () => ({
+  default: { get: vi.fn() },
+}))
+
+describe('consumptionRecordApi', () => {
+  it('getList: SKIPPED/CONSUMED을 saved/consume으로 매핑하고 날짜를 한글로 변환한다', async () => {
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: 'OK',
+        data: [
+          {
+            id: '1',
+            type: 'SKIPPED',
+            productName: '투썸플레이스 신봉점',
+            price: 6100,
+            categoryCode: 'CAFE_DESSERT',
+            categoryLabel: '카페/디저트',
+            reason: '스트레스 받아서',
+            occurredAt: '2026-04-17T12:00:00.000Z',
+          },
+        ],
+      },
+    })
+
+    const result = await consumptionRecordApi.getList('all')
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/consumption-records', {
+      params: { type: 'ALL' },
+    })
+    expect(result).toEqual([
+      {
+        id: '1',
+        title: '투썸플레이스 신봉점',
+        category: '카페/디저트',
+        amount: 6100,
+        type: 'saved',
+        date: '2026년 4월 17일',
+        reason: '스트레스 받아서',
+      },
+    ])
+  })
+
+  it('getList: 필터를 API enum(SKIPPED/CONSUMED)으로 변환해 쿼리파라미터로 전달한다', async () => {
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: { success: true, message: 'OK', data: [] },
+    })
+
+    await consumptionRecordApi.getList('saved')
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/consumption-records', {
+      params: { type: 'SKIPPED' },
+    })
+  })
+
+  it('getList: price가 null이면 0으로, reason이 null이면 undefined로 처리한다', async () => {
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: 'OK',
+        data: [
+          {
+            id: '2',
+            type: 'CONSUMED',
+            productName: '쿠팡 상품',
+            price: null,
+            categoryCode: 'FASHION',
+            categoryLabel: '패션',
+            reason: null,
+            occurredAt: '2026-04-17T12:00:00.000Z',
+          },
+        ],
+      },
+    })
+
+    const [result] = await consumptionRecordApi.getList()
+
+    expect(result.amount).toBe(0)
+    expect(result.reason).toBeUndefined()
+  })
+
+  it('getDetail: recentCategoryConsumptions도 동일한 규칙으로 매핑한다', async () => {
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: 'OK',
+        data: {
+          id: '1',
+          type: 'CONSUMED',
+          productName: 'ZARA 반팔티',
+          price: 23900,
+          categoryCode: 'FASHION',
+          categoryLabel: '패션',
+          reason: '계절이 바뀌어서',
+          occurredAt: '2026-04-17T12:00:00.000Z',
+          recentCategoryConsumptionCount: 1,
+          recentCategoryConsumptions: [
+            {
+              id: '3',
+              type: 'SKIPPED',
+              productName: '무신사',
+              price: 35000,
+              categoryCode: 'FASHION',
+              categoryLabel: '패션',
+              reason: '세일해서',
+              occurredAt: '2026-04-14T12:00:00.000Z',
+            },
+          ],
+        },
+      },
+    })
+
+    const result = await consumptionRecordApi.getDetail('1')
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/consumption-records/1')
+    expect(result.title).toBe('ZARA 반팔티')
+    expect(result.recentCategoryConsumptions).toEqual([
+      {
+        id: '3',
+        title: '무신사',
+        category: '패션',
+        amount: 35000,
+        type: 'saved',
+        date: '2026년 4월 14일',
+        reason: '세일해서',
+      },
+    ])
+  })
+})

--- a/src/features/record/api/consumptionRecordApi.test.ts
+++ b/src/features/record/api/consumptionRecordApi.test.ts
@@ -130,4 +130,42 @@ describe('consumptionRecordApi', () => {
       },
     ])
   })
+
+  it('getDetail: recentCategoryConsumptionCount는 배열 길이가 아니라 API 응답값을 그대로 사용한다', async () => {
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: 'OK',
+        data: {
+          id: '1',
+          type: 'CONSUMED',
+          productName: 'ZARA 반팔티',
+          price: 23900,
+          categoryCode: 'FASHION',
+          categoryLabel: '패션',
+          reason: null,
+          occurredAt: '2026-04-17T12:00:00.000Z',
+          // 응답 배열은 최근 1건만 담고 있지만, 실제 총 건수는 5건인 상황을 가정합니다.
+          recentCategoryConsumptionCount: 5,
+          recentCategoryConsumptions: [
+            {
+              id: '3',
+              type: 'SKIPPED',
+              productName: '무신사',
+              price: 35000,
+              categoryCode: 'FASHION',
+              categoryLabel: '패션',
+              reason: null,
+              occurredAt: '2026-04-14T12:00:00.000Z',
+            },
+          ],
+        },
+      },
+    })
+
+    const result = await consumptionRecordApi.getDetail('1')
+
+    expect(result.recentCategoryConsumptionCount).toBe(5)
+    expect(result.recentCategoryConsumptions).toHaveLength(1)
+  })
 })

--- a/src/features/record/api/consumptionRecordApi.test.ts
+++ b/src/features/record/api/consumptionRecordApi.test.ts
@@ -40,6 +40,7 @@ describe('consumptionRecordApi', () => {
         amount: 6100,
         type: 'saved',
         date: '2026년 4월 17일',
+        occurredAt: '2026-04-17T12:00:00.000Z',
         reason: '스트레스 받아서',
       },
     ])
@@ -126,6 +127,7 @@ describe('consumptionRecordApi', () => {
         amount: 35000,
         type: 'saved',
         date: '2026년 4월 14일',
+        occurredAt: '2026-04-14T12:00:00.000Z',
         reason: '세일해서',
       },
     ])

--- a/src/features/record/api/consumptionRecordApi.ts
+++ b/src/features/record/api/consumptionRecordApi.ts
@@ -52,6 +52,7 @@ function adaptRecord(result: ConsumptionRecordResult): RecordItem {
     amount: result.price ?? 0,
     type: TYPE_TO_FRONT[result.type],
     date: formatDateKorean(result.occurredAt),
+    occurredAt: result.occurredAt,
     reason: result.reason ?? undefined,
   }
 }

--- a/src/features/record/api/consumptionRecordApi.ts
+++ b/src/features/record/api/consumptionRecordApi.ts
@@ -27,6 +27,7 @@ interface ConsumptionRecordDetailResult extends ConsumptionRecordResult {
 }
 
 export interface RecordDetail extends RecordItem {
+  recentCategoryConsumptionCount: number
   recentCategoryConsumptions: RecordItem[]
 }
 
@@ -70,6 +71,7 @@ export const consumptionRecordApi = {
     )
     return {
       ...adaptRecord(data.data),
+      recentCategoryConsumptionCount: data.data.recentCategoryConsumptionCount,
       recentCategoryConsumptions: data.data.recentCategoryConsumptions.map(adaptRecord),
     }
   },

--- a/src/features/record/api/consumptionRecordApi.ts
+++ b/src/features/record/api/consumptionRecordApi.ts
@@ -1,0 +1,76 @@
+import client from '@/api/client'
+import { formatDateKorean } from '@/shared/utils/date'
+import type { RecordItem, RecordType } from '@/features/record/mockRecords'
+
+type ApiRecordType = 'CONSUMED' | 'SKIPPED'
+
+interface ApiResponse<T> {
+  success: boolean
+  message: string
+  data: T
+}
+
+interface ConsumptionRecordResult {
+  id: string
+  type: ApiRecordType
+  productName: string
+  price: number | null
+  categoryCode: string
+  categoryLabel: string
+  reason: string | null
+  occurredAt: string
+}
+
+interface ConsumptionRecordDetailResult extends ConsumptionRecordResult {
+  recentCategoryConsumptionCount: number
+  recentCategoryConsumptions: ConsumptionRecordResult[]
+}
+
+export interface RecordDetail extends RecordItem {
+  recentCategoryConsumptions: RecordItem[]
+}
+
+export type RecordListFilter = 'all' | RecordType
+
+const TYPE_TO_FRONT: Record<ApiRecordType, RecordType> = {
+  SKIPPED: 'saved',
+  CONSUMED: 'consume',
+}
+
+const FILTER_TO_API: Record<RecordListFilter, 'ALL' | ApiRecordType> = {
+  all: 'ALL',
+  saved: 'SKIPPED',
+  consume: 'CONSUMED',
+}
+
+function adaptRecord(result: ConsumptionRecordResult): RecordItem {
+  return {
+    id: result.id,
+    title: result.productName,
+    category: result.categoryLabel,
+    amount: result.price ?? 0,
+    type: TYPE_TO_FRONT[result.type],
+    date: formatDateKorean(result.occurredAt),
+    reason: result.reason ?? undefined,
+  }
+}
+
+export const consumptionRecordApi = {
+  getList: async (filter: RecordListFilter = 'all'): Promise<RecordItem[]> => {
+    const { data } = await client.get<ApiResponse<ConsumptionRecordResult[]>>(
+      '/api/v1/consumption-records',
+      { params: { type: FILTER_TO_API[filter] } },
+    )
+    return data.data.map(adaptRecord)
+  },
+
+  getDetail: async (id: string): Promise<RecordDetail> => {
+    const { data } = await client.get<ApiResponse<ConsumptionRecordDetailResult>>(
+      `/api/v1/consumption-records/${id}`,
+    )
+    return {
+      ...adaptRecord(data.data),
+      recentCategoryConsumptions: data.data.recentCategoryConsumptions.map(adaptRecord),
+    }
+  },
+}

--- a/src/features/record/components/RecordList/RecordList.module.css
+++ b/src/features/record/components/RecordList/RecordList.module.css
@@ -5,3 +5,26 @@
 
   padding: 0 20px 126px;
 }
+
+.message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 60px 20px;
+  font-size: 14px;
+  color: var(--color-gray-300, #5b6b6a);
+  text-align: center;
+}
+
+.retryButton {
+  height: 36px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 8px;
+  background: var(--color-main-500, #2f7f82);
+  color: var(--color-text-white, #fefefe);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}

--- a/src/features/record/components/RecordList/RecordList.tsx
+++ b/src/features/record/components/RecordList/RecordList.tsx
@@ -1,7 +1,7 @@
 import styles from './RecordList.module.css'
 import DateSection from '../DateSection'
 import RecordCard from '../RecordCard'
-import { MOCK_RECORDS } from '@/features/record/mockRecords'
+import { useConsumptionRecords } from '@/features/record/hooks/useConsumptionRecords'
 import type { RecordType } from '@/features/record/mockRecords'
 
 export type FilterValue = 'all' | RecordType
@@ -11,16 +11,35 @@ interface RecordListProps {
 }
 
 export default function RecordList({ filter }: RecordListProps) {
-  const filtered =
-    filter === 'all' ? MOCK_RECORDS : MOCK_RECORDS.filter((record) => record.type === filter)
+  const { data, isLoading, isError, refetch } = useConsumptionRecords(filter)
 
-  const dates = Array.from(new Set(filtered.map((record) => record.date)))
+  if (isLoading) {
+    return <p className={styles.message}>불러오는 중...</p>
+  }
+
+  if (isError) {
+    return (
+      <div className={styles.message}>
+        <p>소비 기록을 불러오지 못했습니다.</p>
+        <button type="button" className={styles.retryButton} onClick={() => refetch()}>
+          다시 시도
+        </button>
+      </div>
+    )
+  }
+
+  const records = data ?? []
+  const dates = Array.from(new Set(records.map((record) => record.date)))
+
+  if (dates.length === 0) {
+    return <p className={styles.message}>기록이 없습니다.</p>
+  }
 
   return (
     <div className={styles.container}>
       {dates.map((date) => (
         <DateSection key={date} date={date}>
-          {filtered
+          {records
             .filter((record) => record.date === date)
             .map((record) => (
               <RecordCard

--- a/src/features/record/hooks/useConsumptionRecords.ts
+++ b/src/features/record/hooks/useConsumptionRecords.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
+import { consumptionRecordApi } from '../api/consumptionRecordApi'
+import type { RecordListFilter } from '../api/consumptionRecordApi'
+
+const QUERY_KEYS = {
+  list: (filter: RecordListFilter) => ['consumption-records', filter] as const,
+  detail: (id: string) => ['consumption-records', id] as const,
+}
+
+export function useConsumptionRecords(filter: RecordListFilter = 'all') {
+  return useQuery({
+    queryKey: QUERY_KEYS.list(filter),
+    queryFn: () => consumptionRecordApi.getList(filter),
+    staleTime: 1000 * 60,
+  })
+}
+
+export function useConsumptionRecordDetail(id: string | undefined) {
+  return useQuery({
+    queryKey: QUERY_KEYS.detail(id ?? ''),
+    queryFn: () => consumptionRecordApi.getDetail(id as string),
+    enabled: Boolean(id),
+    staleTime: 1000 * 60,
+    retry: (failureCount, err) => {
+      if (isAxiosError(err) && err.response?.status === 404) return false
+      return failureCount < 3
+    },
+  })
+}

--- a/src/features/record/hooks/useConsumptionRecords.ts
+++ b/src/features/record/hooks/useConsumptionRecords.ts
@@ -4,8 +4,8 @@ import { consumptionRecordApi } from '../api/consumptionRecordApi'
 import type { RecordListFilter } from '../api/consumptionRecordApi'
 
 const QUERY_KEYS = {
-  list: (filter: RecordListFilter) => ['consumption-records', filter] as const,
-  detail: (id: string) => ['consumption-records', id] as const,
+  list: (filter: RecordListFilter) => ['consumption-records', 'list', filter] as const,
+  detail: (id: string) => ['consumption-records', 'detail', id] as const,
 }
 
 export function useConsumptionRecords(filter: RecordListFilter = 'all') {

--- a/src/features/record/mockRecords.ts
+++ b/src/features/record/mockRecords.ts
@@ -7,6 +7,7 @@ export interface RecordItem {
   amount: number
   type: RecordType
   date: string
+  occurredAt: string
   reason?: string
   thumbnail?: string
 }
@@ -20,6 +21,7 @@ export const MOCK_RECORDS: RecordItem[] = [
     amount: 6100,
     type: 'saved',
     date: '2026년 4월 17일',
+    occurredAt: '2026-04-17T00:00:00.000Z',
     reason: '스트레스 받아서',
   },
   {
@@ -29,6 +31,7 @@ export const MOCK_RECORDS: RecordItem[] = [
     amount: 23900,
     type: 'consume',
     date: '2026년 4월 17일',
+    occurredAt: '2026-04-17T00:00:00.000Z',
     reason: '계절이 바뀌어서',
   },
   {
@@ -38,6 +41,7 @@ export const MOCK_RECORDS: RecordItem[] = [
     amount: 35000,
     type: 'saved',
     date: '2026년 4월 14일',
+    occurredAt: '2026-04-14T00:00:00.000Z',
     reason: '세일해서',
   },
 ]

--- a/src/features/record/pages/RecordDetailPage.module.css
+++ b/src/features/record/pages/RecordDetailPage.module.css
@@ -6,6 +6,29 @@
   padding-bottom: 24px;
 }
 
+.message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 60px 20px;
+  font-size: 14px;
+  color: var(--color-gray-300, #5b6b6a);
+  text-align: center;
+}
+
+.retryButton {
+  height: 36px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 8px;
+  background: var(--color-main-500, #2f7f82);
+  color: var(--color-text-white, #fefefe);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
 .titleRow {
   display: flex;
   align-items: center;

--- a/src/features/record/pages/RecordDetailPage.tsx
+++ b/src/features/record/pages/RecordDetailPage.tsx
@@ -88,7 +88,7 @@ export default function RecordDetailPage() {
         )}
 
         <RecentSpendingList
-          count={record.recentCategoryConsumptions.length}
+          count={record.recentCategoryConsumptionCount}
           records={record.recentCategoryConsumptions.map((item) => ({
             id: item.id,
             title: item.title,

--- a/src/features/record/pages/RecordDetailPage.tsx
+++ b/src/features/record/pages/RecordDetailPage.tsx
@@ -7,17 +7,8 @@ import HeaderBackButton from '@/shared/components/HeaderBackButton'
 import RecentSpendingList from '@/features/intervention/components/RecentSpendingList'
 import { useConsumptionRecordDetail } from '@/features/record/hooks/useConsumptionRecords'
 import { formatKRW } from '@/shared/utils/currency'
+import { formatDateCompact } from '@/shared/utils/date'
 import styles from './RecordDetailPage.module.css'
-
-// 서버가 내려주는 날짜(occurredAt)를 "YYYY년 M월 D일" 형식으로 받은 뒤,
-// 상세 화면 표기(YYYY.MM.DD)로 다시 변환합니다.
-function formatDateCompact(dateLabel: string) {
-  const match = dateLabel.match(/(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일/)
-  if (!match) return dateLabel
-
-  const [, year, month, day] = match
-  return `${year}.${month.padStart(2, '0')}.${day.padStart(2, '0')}`
-}
 
 export default function RecordDetailPage() {
   const { id } = useParams<{ id: string }>()
@@ -73,7 +64,7 @@ export default function RecordDetailPage() {
               <p className={`${styles.amount} ${record.type === 'consume' ? styles.consume : ''}`}>
                 {record.type === 'saved' ? '+' : '-'} {formatKRW(record.amount)}
               </p>
-              <p className={styles.date}>{formatDateCompact(record.date)}</p>
+              <p className={styles.date}>{formatDateCompact(record.occurredAt)}</p>
             </div>
           </div>
         }

--- a/src/features/record/pages/RecordDetailPage.tsx
+++ b/src/features/record/pages/RecordDetailPage.tsx
@@ -1,15 +1,16 @@
 import { useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
+import { isAxiosError } from 'axios'
 import { IoPencilOutline } from 'react-icons/io5'
 import Header from '@/components/layout/Header'
 import HeaderBackButton from '@/shared/components/HeaderBackButton'
 import RecentSpendingList from '@/features/intervention/components/RecentSpendingList'
-import { MOCK_RECORDS } from '@/features/record/mockRecords'
+import { useConsumptionRecordDetail } from '@/features/record/hooks/useConsumptionRecords'
 import { formatKRW } from '@/shared/utils/currency'
 import styles from './RecordDetailPage.module.css'
 
-// 목데이터의 날짜가 "2026년 4월 17일" 형식이라 상세 화면 표기(YYYY.MM.DD)로 변환합니다.
-// API 연결 시 서버에서 포맷된 날짜를 받도록 수정 예정입니다.
+// 서버가 내려주는 날짜(occurredAt)를 "YYYY년 M월 D일" 형식으로 받은 뒤,
+// 상세 화면 표기(YYYY.MM.DD)로 다시 변환합니다.
 function formatDateCompact(dateLabel: string) {
   const match = dateLabel.match(/(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일/)
   if (!match) return dateLabel
@@ -22,19 +23,33 @@ export default function RecordDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
 
-  const record = MOCK_RECORDS.find((item) => item.id === id)
+  const { data: record, isLoading, isError, error, refetch } = useConsumptionRecordDetail(id)
+  const isNotFound = isAxiosError(error) && error.response?.status === 404
 
   useEffect(() => {
-    if (!record) {
+    if (isNotFound) {
       navigate('/record', { replace: true })
     }
-  }, [record, navigate])
+  }, [isNotFound, navigate])
+
+  if (isLoading) {
+    return <p className={styles.message}>불러오는 중...</p>
+  }
+
+  if (isNotFound) return null
+
+  if (isError) {
+    return (
+      <div className={styles.message}>
+        <p>소비 기록을 불러오지 못했습니다.</p>
+        <button type="button" className={styles.retryButton} onClick={() => refetch()}>
+          다시 시도
+        </button>
+      </div>
+    )
+  }
 
   if (!record) return null
-
-  const recentRecords = MOCK_RECORDS.filter(
-    (item) => item.category === record.category && item.id !== record.id,
-  )
 
   return (
     <div>
@@ -73,8 +88,8 @@ export default function RecordDetailPage() {
         )}
 
         <RecentSpendingList
-          count={recentRecords.length}
-          records={recentRecords.map((item) => ({
+          count={record.recentCategoryConsumptions.length}
+          records={record.recentCategoryConsumptions.map((item) => ({
             id: item.id,
             title: item.title,
             date: item.date,

--- a/src/shared/utils/date.test.ts
+++ b/src/shared/utils/date.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { formatDateCompact, formatDateKorean } from './date'
+
+describe('formatDateKorean / formatDateCompact', () => {
+  it('자정 근처 UTC 시각도 KST 기준 날짜로 표시한다 (실행 환경의 로컬 시간대와 무관하게)', () => {
+    // 2026-08-09T00:30:00.000Z는 KST(UTC+9)로 2026-08-09 09:30이므로 8월 9일이어야 합니다.
+    // 로컬 Date getter를 썼다면 UTC-10 이상 서쪽 시간대에서 8월 8일로 잘못 표시됩니다.
+    expect(formatDateKorean('2026-08-09T00:30:00.000Z')).toBe('2026년 8월 9일')
+    expect(formatDateCompact('2026-08-09T00:30:00.000Z')).toBe('2026.08.09')
+  })
+
+  it('KST 자정 이전 UTC 시각은 하루 전 날짜로 표시한다', () => {
+    // 2026-08-08T14:30:00.000Z는 KST로 2026-08-08 23:30이므로 8월 8일이어야 합니다.
+    expect(formatDateKorean('2026-08-08T14:30:00.000Z')).toBe('2026년 8월 8일')
+    expect(formatDateCompact('2026-08-08T14:30:00.000Z')).toBe('2026.08.08')
+  })
+
+  it('한 자리 월/일을 두 자리로 패딩한다', () => {
+    expect(formatDateCompact('2026-04-05T03:00:00.000Z')).toBe('2026.04.05')
+  })
+})

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -13,3 +13,15 @@ export function getDayIndex(length: number, date: Date = new Date()): number {
   const dayOfYear = Math.floor((today.getTime() - start.getTime()) / 86400000)
   return dayOfYear % length
 }
+
+export function formatDateKorean(isoDate: string): string {
+  const date = new Date(isoDate)
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`
+}
+
+export function formatDateCompact(isoDate: string): string {
+  const date = new Date(isoDate)
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${date.getFullYear()}.${month}.${day}`
+}

--- a/src/shared/utils/date.ts
+++ b/src/shared/utils/date.ts
@@ -14,14 +14,27 @@ export function getDayIndex(length: number, date: Date = new Date()): number {
   return dayOfYear % length
 }
 
+// 서버 응답(occurredAt)은 KST 기준 날짜 계약이므로, 브라우저 로컬 시간대와 무관하게
+// 항상 Asia/Seoul 기준으로 날짜를 뽑아냅니다.
+const KST_DATE_FORMATTER = new Intl.DateTimeFormat('ko-KR', {
+  timeZone: 'Asia/Seoul',
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+})
+
+function getKstDateParts(isoDate: string) {
+  const parts = KST_DATE_FORMATTER.formatToParts(new Date(isoDate))
+  const get = (type: string) => parts.find((part) => part.type === type)?.value ?? ''
+  return { year: get('year'), month: get('month'), day: get('day') }
+}
+
 export function formatDateKorean(isoDate: string): string {
-  const date = new Date(isoDate)
-  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`
+  const { year, month, day } = getKstDateParts(isoDate)
+  return `${year}년 ${month}월 ${day}일`
 }
 
 export function formatDateCompact(isoDate: string): string {
-  const date = new Date(isoDate)
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${date.getFullYear()}.${month}.${day}`
+  const { year, month, day } = getKstDateParts(isoDate)
+  return `${year}.${month.padStart(2, '0')}.${day.padStart(2, '0')}`
 }


### PR DESCRIPTION
## 📌 작업 내용

- `GET /api/v1/consumption-records` (목록, `type` 쿼리파라미터로 전체/참은 소비/소비 필터) 연동
- `GET /api/v1/consumption-records/{consumptionRecordId}` (상세) 연동
- `src/features/record/api/consumptionRecordApi.ts` 추가: API 응답(`CONSUMED`/`SKIPPED`, `categoryLabel`, `occurredAt` 등)을 기존 프론트 타입(`RecordItem`, saved/consume)으로 매핑하는 어댑터 작성
- `useConsumptionRecords`, `useConsumptionRecordDetail` react-query 훅 추가
- `RecordList`: `MOCK_RECORDS` 제거, 로딩/에러(재시도)/빈 상태 UI 추가
- `RecordDetailPage`: 상세 API 연동, `recentCategoryConsumptions`는 서버 응답을 그대로 사용하도록 변경(기존 프론트 필터링 로직 제거), 존재하지 않는 id 접근 시 목록으로 즉시 리다이렉트
- `shared/utils/date.ts`: ISO 날짜 → "2026년 4월 17일" / "2026.04.17" 포맷 함수 추가
- 어댑터 매핑 로직에 대한 단위 테스트 추가 (`consumptionRecordApi.test.ts`)
</br>

## 📷 스크린 샷
> 기록 없을 때
<img width="400" alt="image" src="https://github.com/user-attachments/assets/213a89de-8e5a-41f2-b218-4eaf31e21668" />

> 기록 있을 때
<img width="400" alt="image" src="https://github.com/user-attachments/assets/cae3b7e1-2232-4866-be45-ec9f3c5bbf4f" />

> 상세 화면
<img width="400" alt="image" src="https://github.com/user-attachments/assets/dcec6dc9-ab47-41fa-a94b-1dc9d585a654" />

</br>

## ⚠️ 참고 사항
- 실제 배포된 백엔드(`https://donworry-api-61976702501.asia-northeast3.run.app`)로 목록/상세/필터/404 리다이렉트까지 직접 로그인 토큰 발급받아 실 데이터로 확인 완료했습니다.
- react-query가 기본적으로 실패 시 3회 재시도하는데, 상세 조회에서 404는 재시도해도 의미가 없어 재시도 대상에서 제외했습니다 (안 그러면 리다이렉트가 몇 초 지연됨).
- 상세에서 최근 비슷한 소비 목록에 해당 소비는 지우고 출력해달라고 백엔드에 요청하려 합니다 
-
</br>

## 🔗 관련 이슈
Closes #93 
</br>
