### PR TITLE
✨ [Feature] 소비 기록 입력/수정/삭제 API 연동

### DIFF
--- a/src/features/intervention/pages/RecordInterventionPage.tsx
+++ b/src/features/intervention/pages/RecordInterventionPage.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
 import InterventionHeader from '@/features/intervention/components/InterventionHeader'
 import AnswerButton from '@/features/intervention/components/AnswerButton'
 import RecentSpendingList from '@/features/intervention/components/RecentSpendingList'
 import type { RecentSpendingItem } from '@/features/intervention/components/RecentSpendingList'
+import type { RecordDraft } from '@/features/record/pages/RecordCreatePage'
 import styles from '../styles/RecordInterventionPage.module.css'
 
 interface AnswerOption {
@@ -54,9 +55,20 @@ const TOTAL_STEPS = QUESTIONS.length
 
 export default function RecordInterventionPage() {
   const navigate = useNavigate()
+  const location = useLocation()
+  const draft = (location.state as { draft?: RecordDraft } | null)?.draft
+
+  useEffect(() => {
+    if (!draft) {
+      navigate('/record/new', { replace: true })
+    }
+  }, [draft, navigate])
+
   const [step, setStep] = useState(1)
   const [answers, setAnswers] = useState<number[]>([])
   const question = QUESTIONS[step - 1]
+
+  if (!draft) return null
 
   const handleAnswer = (optionScore: number) => {
     const nextAnswers = [...answers, optionScore]
@@ -68,7 +80,10 @@ export default function RecordInterventionPage() {
     }
 
     const totalScore = nextAnswers.reduce((sum, value) => sum + value, 0)
-    navigate(`/record/intervention/result?score=${totalScore}`, { replace: true })
+    navigate(`/record/intervention/result?score=${totalScore}`, {
+      replace: true,
+      state: { draft },
+    })
   }
 
   const handleBack = () => {

--- a/src/features/intervention/pages/RiskResultPage.tsx
+++ b/src/features/intervention/pages/RiskResultPage.tsx
@@ -54,6 +54,7 @@ export default function RiskResultPage() {
         category: draft.category,
         reason: draft.reason,
         riskScore: score,
+        productUrl: draft.productUrl,
       },
       { onSuccess: () => navigate('/record', { replace: true }) },
     )

--- a/src/features/intervention/pages/RiskResultPage.tsx
+++ b/src/features/intervention/pages/RiskResultPage.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useState } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import BackButton from '@/features/intervention/components/BackButton'
 import AnswerButton from '@/features/intervention/components/AnswerButton'
 import CountdownTimer from '@/features/intervention/components/CountdownTimer'
 import { getRiskLevel, parseRiskScore } from '@/features/intervention/utils/riskLevel'
 import type { RiskLevel } from '@/features/intervention/utils/riskLevel'
+import type { RecordDraft } from '@/features/record/pages/RecordCreatePage'
+import type { RecordType } from '@/features/record/mockRecords'
+import { useCreateConsumptionRecord } from '@/features/record/hooks/useConsumptionRecords'
 import styles from '../styles/RiskResultPage.module.css'
 
-// 하드코딩됨. API 연결 시 수정 예정
-const ITEM_NAME = '쿠어 워시드 디테처블 후드 점퍼(블랙)'
+// 하드코딩됨. 급여(시급) 정보를 다루는 기능이 아직 없어 실제 근무 시간 계산 API 연결 전까지 유지합니다.
 const WORK_HOURS = 26
 
 const RISK_CONTENT: Record<RiskLevel, { heading: string; timerSeconds: number | null }> = {
@@ -22,22 +24,40 @@ const RISK_CONTENT: Record<RiskLevel, { heading: string; timerSeconds: number | 
 
 export default function RiskResultPage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const [searchParams] = useSearchParams()
 
   const score = parseRiskScore(searchParams.get('score'))
+  const draft = (location.state as { draft?: RecordDraft } | null)?.draft
+
+  const createRecord = useCreateConsumptionRecord()
 
   useEffect(() => {
-    if (score === null) {
-      navigate('/record/intervention', { replace: true })
+    if (score === null || !draft) {
+      navigate('/record/new', { replace: true })
     }
-  }, [score, navigate])
+  }, [score, draft, navigate])
 
   const riskLevel = score !== null ? getRiskLevel(score) : 'low'
   const { heading, timerSeconds } = RISK_CONTENT[riskLevel]
 
   const [waitComplete, setWaitComplete] = useState(timerSeconds === null)
 
-  if (score === null) return null
+  if (score === null || !draft) return null
+
+  const handleDecision = (type: RecordType) => {
+    createRecord.mutate(
+      {
+        type,
+        productName: draft.title,
+        price: draft.amount,
+        category: draft.category,
+        reason: draft.reason,
+        riskScore: score,
+      },
+      { onSuccess: () => navigate('/record', { replace: true }) },
+    )
+  }
 
   return (
     <div className={styles.container}>
@@ -50,7 +70,7 @@ export default function RiskResultPage() {
       </h1>
 
       <p className={styles.description}>
-        {ITEM_NAME}을
+        {draft.title}을
         <br />
         사기 위해서는 <strong className={styles.highlight}>아르바이트 {WORK_HOURS}시간</strong> 동안
         근무해야 합니다
@@ -62,13 +82,22 @@ export default function RiskResultPage() {
         )}
       </div>
 
+      {createRecord.isError && (
+        <p className={styles.errorText}>저장에 실패했습니다. 다시 시도해주세요.</p>
+      )}
+
       <div className={styles.buttons}>
-        <AnswerButton label="안 살게요" variant="outline" onClick={() => navigate('/record')} />
+        <AnswerButton
+          label="안 살게요"
+          variant="outline"
+          disabled={createRecord.isPending}
+          onClick={() => handleDecision('saved')}
+        />
         <AnswerButton
           label="그래도 살게요"
           variant="filled"
-          disabled={!waitComplete}
-          onClick={() => navigate('/record')}
+          disabled={!waitComplete || createRecord.isPending}
+          onClick={() => handleDecision('consume')}
         />
       </div>
     </div>

--- a/src/features/intervention/styles/RiskResultPage.module.css
+++ b/src/features/intervention/styles/RiskResultPage.module.css
@@ -37,6 +37,13 @@
   justify-content: center;
 }
 
+.errorText {
+  margin: 0 0 12px;
+  font-size: 13px;
+  color: #eb0000;
+  text-align: center;
+}
+
 .buttons {
   display: flex;
   flex-direction: column;

--- a/src/features/record/api/consumptionRecordApi.test.ts
+++ b/src/features/record/api/consumptionRecordApi.test.ts
@@ -264,4 +264,37 @@ describe('consumptionRecordApi', () => {
 
     expect(client.delete).toHaveBeenCalledWith('/api/v1/consumption-records/1')
   })
+
+  it('create: productUrl이 있으면 요청 바디에 포함한다', async () => {
+    vi.mocked(client.post).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: 'OK',
+        data: {
+          id: '3',
+          type: 'CONSUMED',
+          productName: '캠핑 의자',
+          price: 45000,
+          categoryCode: 'HOBBY_GOODS',
+          categoryLabel: '취미/굿즈',
+          reason: null,
+          occurredAt: '2026-08-09T12:00:00.000Z',
+        },
+      },
+    })
+
+    await consumptionRecordApi.create({
+      type: 'consume',
+      productName: '캠핑 의자',
+      price: 45000,
+      productUrl: 'https://example.com/products/chair',
+    })
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/consumption-records', {
+      type: 'CONSUMED',
+      productName: '캠핑 의자',
+      price: 45000,
+      productUrl: 'https://example.com/products/chair',
+    })
+  })
 })

--- a/src/features/record/api/consumptionRecordApi.test.ts
+++ b/src/features/record/api/consumptionRecordApi.test.ts
@@ -3,7 +3,7 @@ import client from '@/api/client'
 import { consumptionRecordApi } from './consumptionRecordApi'
 
 vi.mock('@/api/client', () => ({
-  default: { get: vi.fn() },
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
 }))
 
 describe('consumptionRecordApi', () => {
@@ -157,5 +157,111 @@ describe('consumptionRecordApi', () => {
       skippedRatio: 65,
       consumedRatio: 35,
     })
+  })
+
+  it('create: saved/consume을 SKIPPED/CONSUMED로, 카테고리 라벨을 코드로 변환해 전송한다', async () => {
+    vi.mocked(client.post).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: '소비 기록 생성에 성공했습니다.',
+        data: {
+          id: '1',
+          type: 'SKIPPED',
+          productName: '무선 이어폰',
+          price: 150000,
+          categoryCode: 'ELECTRONICS',
+          categoryLabel: '전자기기',
+          reason: '비슷한 걸 이미 가지고 있어서',
+          occurredAt: '2026-08-09T12:00:00.000Z',
+        },
+      },
+    })
+
+    const result = await consumptionRecordApi.create({
+      type: 'saved',
+      productName: '무선 이어폰',
+      price: 150000,
+      category: '전자기기',
+      reason: '비슷한 걸 이미 가지고 있어서',
+    })
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/consumption-records', {
+      type: 'SKIPPED',
+      productName: '무선 이어폰',
+      price: 150000,
+      category_code: 'ELECTRONICS',
+      reason: '비슷한 걸 이미 가지고 있어서',
+    })
+    expect(result.type).toBe('saved')
+    expect(result.category).toBe('전자기기')
+  })
+
+  it('create: category/reason/riskScore가 없으면 요청 바디에 포함하지 않는다', async () => {
+    vi.mocked(client.post).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: 'OK',
+        data: {
+          id: '2',
+          type: 'CONSUMED',
+          productName: '아메리카노',
+          price: 4500,
+          categoryCode: null,
+          categoryLabel: null,
+          reason: null,
+          occurredAt: '2026-08-09T12:00:00.000Z',
+        },
+      },
+    })
+
+    await consumptionRecordApi.create({ type: 'consume', productName: '아메리카노', price: 4500 })
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/consumption-records', {
+      type: 'CONSUMED',
+      productName: '아메리카노',
+      price: 4500,
+    })
+  })
+
+  it('update: PUT으로 요청하고 응답을 프론트 타입으로 변환한다', async () => {
+    vi.mocked(client.put).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: 'OK',
+        data: {
+          id: '1',
+          type: 'CONSUMED',
+          productName: '수정된 상품명',
+          price: 10000,
+          categoryCode: 'FASHION',
+          categoryLabel: '패션',
+          reason: null,
+          occurredAt: '2026-08-09T12:00:00.000Z',
+        },
+      },
+    })
+
+    const result = await consumptionRecordApi.update('1', {
+      type: 'consume',
+      productName: '수정된 상품명',
+      price: 10000,
+      category: '패션',
+    })
+
+    expect(client.put).toHaveBeenCalledWith('/api/v1/consumption-records/1', {
+      type: 'CONSUMED',
+      productName: '수정된 상품명',
+      price: 10000,
+      category_code: 'FASHION',
+    })
+    expect(result.title).toBe('수정된 상품명')
+  })
+
+  it('remove: DELETE로 요청한다', async () => {
+    vi.mocked(client.delete).mockResolvedValueOnce({ data: { success: true } })
+
+    await consumptionRecordApi.remove('1')
+
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/consumption-records/1')
   })
 })

--- a/src/features/record/api/consumptionRecordApi.ts
+++ b/src/features/record/api/consumptionRecordApi.ts
@@ -85,6 +85,7 @@ export interface ConsumptionRecordInput {
   category?: string
   reason?: string
   riskScore?: number
+  productUrl?: string
 }
 
 function toRequestBody(input: ConsumptionRecordInput) {
@@ -95,6 +96,7 @@ function toRequestBody(input: ConsumptionRecordInput) {
     ...(input.category && { category_code: CATEGORY_LABEL_TO_CODE[input.category] }),
     ...(input.reason && { reason: input.reason }),
     ...(input.riskScore !== undefined && { riskScore: input.riskScore }),
+    ...(input.productUrl && { productUrl: input.productUrl }),
   }
 }
 

--- a/src/features/record/api/consumptionRecordApi.ts
+++ b/src/features/record/api/consumptionRecordApi.ts
@@ -54,10 +54,48 @@ const TYPE_TO_FRONT: Record<ApiRecordType, RecordType> = {
   CONSUMED: 'consume',
 }
 
+const TYPE_TO_API: Record<RecordType, ApiRecordType> = {
+  saved: 'SKIPPED',
+  consume: 'CONSUMED',
+}
+
 const FILTER_TO_API: Record<RecordListFilter, 'ALL' | ApiRecordType> = {
   all: 'ALL',
   saved: 'SKIPPED',
   consume: 'CONSUMED',
+}
+
+// 백엔드에 실제로 존재하는 카테고리 코드로 확인된 값만 매핑합니다.
+const CATEGORY_LABEL_TO_CODE: Record<string, string> = {
+  패션: 'FASHION',
+  뷰티: 'BEAUTY',
+  음식: 'FOOD_SNACK',
+  '카페/디저트': 'CAFE_DESSERT',
+  '취미/굿즈': 'HOBBY_GOODS',
+  전자기기: 'ELECTRONICS',
+  '건강/운동': 'HEALTH_FITNESS',
+  여행: 'TRAVEL',
+  기타: 'ETC',
+}
+
+export interface ConsumptionRecordInput {
+  type: RecordType
+  productName: string
+  price: number
+  category?: string
+  reason?: string
+  riskScore?: number
+}
+
+function toRequestBody(input: ConsumptionRecordInput) {
+  return {
+    type: TYPE_TO_API[input.type],
+    productName: input.productName,
+    price: input.price,
+    ...(input.category && { category_code: CATEGORY_LABEL_TO_CODE[input.category] }),
+    ...(input.reason && { reason: input.reason }),
+    ...(input.riskScore !== undefined && { riskScore: input.riskScore }),
+  }
 }
 
 function adaptRecord(result: ConsumptionRecordResult): RecordItem {
@@ -97,5 +135,25 @@ export const consumptionRecordApi = {
     )
     const { totalAmount, skippedAmount, consumedAmount, skippedRatio, consumedRatio } = data.data
     return { totalAmount, skippedAmount, consumedAmount, skippedRatio, consumedRatio }
+  },
+
+  create: async (input: ConsumptionRecordInput): Promise<RecordItem> => {
+    const { data } = await client.post<ApiResponse<ConsumptionRecordResult>>(
+      '/api/v1/consumption-records',
+      toRequestBody(input),
+    )
+    return adaptRecord(data.data)
+  },
+
+  update: async (id: string, input: ConsumptionRecordInput): Promise<RecordItem> => {
+    const { data } = await client.put<ApiResponse<ConsumptionRecordResult>>(
+      `/api/v1/consumption-records/${id}`,
+      toRequestBody(input),
+    )
+    return adaptRecord(data.data)
+  },
+
+  remove: async (id: string): Promise<void> => {
+    await client.delete(`/api/v1/consumption-records/${id}`)
   },
 }

--- a/src/features/record/api/productUrlApi.test.ts
+++ b/src/features/record/api/productUrlApi.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import client from '@/api/client'
+import { productUrlApi } from './productUrlApi'
+
+vi.mock('@/api/client', () => ({
+  default: { post: vi.fn() },
+}))
+
+describe('productUrlApi', () => {
+  it('parse: 요청 바디에 productUrl을 담아 보내고 응답 데이터를 그대로 반환한다', async () => {
+    vi.mocked(client.post).mockResolvedValueOnce({
+      data: {
+        success: true,
+        message: 'url 파싱에 성공했습니다.',
+        data: {
+          productName: '투썸플레이스 신봉점',
+          price: 6100,
+          occurredAt: '2026-05-17T12:00:00.000Z',
+        },
+      },
+    })
+
+    const result = await productUrlApi.parse('https://example.com/products/123')
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/product-url/parse', {
+      productUrl: 'https://example.com/products/123',
+    })
+    expect(result).toEqual({
+      productName: '투썸플레이스 신봉점',
+      price: 6100,
+      occurredAt: '2026-05-17T12:00:00.000Z',
+    })
+  })
+})

--- a/src/features/record/api/productUrlApi.ts
+++ b/src/features/record/api/productUrlApi.ts
@@ -1,0 +1,22 @@
+import client from '@/api/client'
+
+interface ApiResponse<T> {
+  success: boolean
+  message: string
+  data: T
+}
+
+export interface ParsedProduct {
+  productName: string
+  price: number
+  occurredAt: string
+}
+
+export const productUrlApi = {
+  parse: async (productUrl: string): Promise<ParsedProduct> => {
+    const { data } = await client.post<ApiResponse<ParsedProduct>>('/api/v1/product-url/parse', {
+      productUrl,
+    })
+    return data.data
+  },
+}

--- a/src/features/record/hooks/useConsumptionRecords.ts
+++ b/src/features/record/hooks/useConsumptionRecords.ts
@@ -1,7 +1,7 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { isAxiosError } from 'axios'
 import { consumptionRecordApi } from '../api/consumptionRecordApi'
-import type { RecordListFilter } from '../api/consumptionRecordApi'
+import type { ConsumptionRecordInput, RecordListFilter } from '../api/consumptionRecordApi'
 
 const QUERY_KEYS = {
   list: (filter: RecordListFilter) => ['consumption-records', filter] as const,
@@ -35,5 +35,36 @@ export function useConsumptionRatio() {
     queryKey: QUERY_KEYS.ratio,
     queryFn: consumptionRecordApi.getRatio,
     staleTime: 1000 * 60,
+  })
+}
+
+export function useCreateConsumptionRecord() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: consumptionRecordApi.create,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['consumption-records'] })
+    },
+  })
+}
+
+export function useUpdateConsumptionRecord() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: ConsumptionRecordInput }) =>
+      consumptionRecordApi.update(id, input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['consumption-records'] })
+    },
+  })
+}
+
+export function useDeleteConsumptionRecord() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: consumptionRecordApi.remove,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['consumption-records'] })
+    },
   })
 }

--- a/src/features/record/hooks/useProductUrl.ts
+++ b/src/features/record/hooks/useProductUrl.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query'
+import { productUrlApi } from '../api/productUrlApi'
+
+export function useParseProductUrl() {
+  return useMutation({
+    mutationFn: productUrlApi.parse,
+  })
+}

--- a/src/features/record/pages/RecordCreatePage.module.css
+++ b/src/features/record/pages/RecordCreatePage.module.css
@@ -52,6 +52,12 @@
   font-weight: 600;
 }
 
+.errorText {
+  margin: -8px 0 0;
+  font-size: 13px;
+  color: #eb0000;
+}
+
 .submitBtn {
   height: 52px;
   margin-top: 8px;

--- a/src/features/record/pages/RecordCreatePage.module.css
+++ b/src/features/record/pages/RecordCreatePage.module.css
@@ -43,6 +43,41 @@
   border-bottom-color: var(--color-main-500, #2f7f82);
 }
 
+.urlRow {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.urlInput {
+  flex: 1;
+  min-width: 0;
+}
+
+.urlButton {
+  flex-shrink: 0;
+  height: 36px;
+  padding: 0 14px;
+  border: none;
+  border-radius: 8px;
+  background: var(--color-text-primary, #243130);
+  color: var(--color-main-000, #f7fbfa);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.urlButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.successText {
+  margin: 0;
+  font-size: 13px;
+  color: #008d02;
+}
+
 .amountWrapper {
   padding-bottom: 4px;
 }

--- a/src/features/record/pages/RecordCreatePage.tsx
+++ b/src/features/record/pages/RecordCreatePage.tsx
@@ -1,21 +1,36 @@
 import { useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { isAxiosError } from 'axios'
+import { IoTrashOutline } from 'react-icons/io5'
 import Header from '@/components/layout/Header'
 import HeaderBackButton from '@/shared/components/HeaderBackButton'
 import TabGroup from '@/shared/components/TabGroup'
+import { ConfirmDialog } from '@/shared/components/ConfirmDialog'
 import AmountInput from '@/components/layout/AmountInput'
 import CategorySelector from '@/components/layout/CategorySelector'
 import type { Category } from '@/components/layout/CategorySelector'
 import { CATEGORIES } from '@/constants/product'
-import { MOCK_RECORDS } from '@/features/record/mockRecords'
 import type { RecordType } from '@/features/record/mockRecords'
+import {
+  useConsumptionRecordDetail,
+  useCreateConsumptionRecord,
+  useUpdateConsumptionRecord,
+  useDeleteConsumptionRecord,
+} from '@/features/record/hooks/useConsumptionRecords'
 import styles from './RecordCreatePage.module.css'
 
 const RECORD_TYPE_OPTIONS: { label: string; value: RecordType }[] = [
   { label: '참았어요', value: 'saved' },
   { label: '샀어요', value: 'consume' },
 ]
+
+export interface RecordDraft {
+  title: string
+  amount: number
+  category: Category
+  reason: string
+}
 
 export default function RecordCreatePage() {
   const { id } = useParams<{ id: string }>()
@@ -27,13 +42,25 @@ export default function RecordCreatePage() {
 function RecordCreateForm({ id }: { id?: string }) {
   const navigate = useNavigate()
   const isEditMode = Boolean(id)
-  const editingRecord = id ? MOCK_RECORDS.find((item) => item.id === id) : undefined
+
+  const {
+    data: editingRecord,
+    isLoading: isLoadingRecord,
+    error: detailError,
+  } = useConsumptionRecordDetail(id)
+  const isNotFound = isAxiosError(detailError) && detailError.response?.status === 404
+
+  const createRecord = useCreateConsumptionRecord()
+  const updateRecord = useUpdateConsumptionRecord()
+  const deleteRecord = useDeleteConsumptionRecord()
+
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
 
   useEffect(() => {
-    if (isEditMode && !editingRecord) {
+    if (isNotFound) {
       navigate('/record', { replace: true })
     }
-  }, [isEditMode, editingRecord, navigate])
+  }, [isNotFound, navigate])
 
   const [type, setType] = useState<RecordType>(editingRecord?.type ?? 'consume')
   const [title, setTitle] = useState(editingRecord?.title ?? '')
@@ -45,24 +72,37 @@ function RecordCreateForm({ id }: { id?: string }) {
 
   const isValid = title.trim() !== '' && amount > 0
 
-  if (isEditMode && !editingRecord) return null
+  if (isEditMode && (isLoadingRecord || isNotFound)) return null
 
-  // 하드코딩됨. 실제 저장(API 연결) 로직은 추후 구현 예정. 지금은 타입에 따라 라우팅만 처리합니다.
+  const submitError = createRecord.isError || updateRecord.isError
+
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
     if (!isValid) return
 
-    if (isEditMode) {
-      navigate(`/record/${id}`)
+    if (isEditMode && id) {
+      updateRecord.mutate(
+        { id, input: { type, productName: title, price: amount, category, reason } },
+        { onSuccess: () => navigate(`/record/${id}`) },
+      )
       return
     }
 
     if (type === 'consume') {
-      navigate('/record/intervention')
+      const draft: RecordDraft = { title, amount, category, reason }
+      navigate('/record/intervention', { state: { draft } })
       return
     }
 
-    navigate('/record')
+    createRecord.mutate(
+      { type, productName: title, price: amount, category, reason },
+      { onSuccess: () => navigate('/record') },
+    )
+  }
+
+  const handleDelete = () => {
+    if (!id) return
+    deleteRecord.mutate(id, { onSuccess: () => navigate('/record', { replace: true }) })
   }
 
   return (
@@ -70,6 +110,13 @@ function RecordCreateForm({ id }: { id?: string }) {
       <Header
         subLeft={<HeaderBackButton />}
         subTitle={isEditMode ? '소비 기록 수정' : '소비 기록 입력'}
+        subRight={
+          isEditMode ? (
+            <button type="button" aria-label="삭제" onClick={() => setIsDeleteDialogOpen(true)}>
+              <IoTrashOutline size={20} />
+            </button>
+          ) : undefined
+        }
         subMain={
           <TabGroup<RecordType>
             variant="segment"
@@ -124,10 +171,27 @@ function RecordCreateForm({ id }: { id?: string }) {
           />
         </div>
 
-        <button type="submit" className={styles.submitBtn} disabled={!isValid}>
+        {submitError && <p className={styles.errorText}>저장에 실패했습니다. 다시 시도해주세요.</p>}
+
+        <button
+          type="submit"
+          className={styles.submitBtn}
+          disabled={!isValid || createRecord.isPending || updateRecord.isPending}
+        >
           {isEditMode ? '수정하기' : '기록하기'}
         </button>
       </form>
+
+      <ConfirmDialog
+        isOpen={isDeleteDialogOpen}
+        title="이 소비 기록을 삭제할까요?"
+        description="삭제한 기록은 복구할 수 없습니다."
+        confirmText="삭제"
+        isLoading={deleteRecord.isPending}
+        errorMessage={deleteRecord.isError ? '삭제에 실패했습니다. 다시 시도해주세요.' : undefined}
+        onCancel={() => setIsDeleteDialogOpen(false)}
+        onConfirm={handleDelete}
+      />
     </div>
   )
 }

--- a/src/features/record/pages/RecordCreatePage.tsx
+++ b/src/features/record/pages/RecordCreatePage.tsx
@@ -101,8 +101,9 @@ function RecordCreateForm({ id, editingRecord }: { id?: string; editingRecord?: 
   const submitError = createRecord.isError || updateRecord.isError
 
   const handleParseUrl = () => {
-    if (!productUrl.trim()) return
-    parseUrl.mutate(productUrl, {
+    const normalizedUrl = productUrl.trim()
+    if (!normalizedUrl) return
+    parseUrl.mutate(normalizedUrl, {
       onSuccess: (data) => {
         setTitle(data.productName)
         setAmount(data.price)
@@ -114,22 +115,47 @@ function RecordCreateForm({ id, editingRecord }: { id?: string; editingRecord?: 
     event.preventDefault()
     if (!isValid) return
 
+    const normalizedProductUrl = productUrl.trim() || undefined
+
     if (isEditMode && id) {
       updateRecord.mutate(
-        { id, input: { type, productName: title, price: amount, category, reason, productUrl } },
+        {
+          id,
+          input: {
+            type,
+            productName: title,
+            price: amount,
+            category,
+            reason,
+            productUrl: normalizedProductUrl,
+          },
+        },
         { onSuccess: () => navigate(`/record/${id}`) },
       )
       return
     }
 
     if (type === 'consume') {
-      const draft: RecordDraft = { title, amount, category, reason, productUrl }
+      const draft: RecordDraft = {
+        title,
+        amount,
+        category,
+        reason,
+        productUrl: normalizedProductUrl,
+      }
       navigate('/record/intervention', { state: { draft } })
       return
     }
 
     createRecord.mutate(
-      { type, productName: title, price: amount, category, reason, productUrl },
+      {
+        type,
+        productName: title,
+        price: amount,
+        category,
+        reason,
+        productUrl: normalizedProductUrl,
+      },
       { onSuccess: () => navigate('/record') },
     )
   }
@@ -172,6 +198,7 @@ function RecordCreateForm({ id, editingRecord }: { id?: string; editingRecord?: 
               className={`${styles.textInput} ${styles.urlInput}`}
               placeholder="https://..."
               value={productUrl}
+              disabled={parseUrl.isPending}
               onChange={(event) => setProductUrl(event.target.value)}
             />
             <button

--- a/src/features/record/pages/RecordCreatePage.tsx
+++ b/src/features/record/pages/RecordCreatePage.tsx
@@ -18,6 +18,7 @@ import {
   useUpdateConsumptionRecord,
   useDeleteConsumptionRecord,
 } from '@/features/record/hooks/useConsumptionRecords'
+import { useParseProductUrl } from '@/features/record/hooks/useProductUrl'
 import styles from './RecordCreatePage.module.css'
 
 const RECORD_TYPE_OPTIONS: { label: string; value: RecordType }[] = [
@@ -30,6 +31,7 @@ export interface RecordDraft {
   amount: number
   category: Category
   reason: string
+  productUrl?: string
 }
 
 export default function RecordCreatePage() {
@@ -53,6 +55,7 @@ function RecordCreateForm({ id }: { id?: string }) {
   const createRecord = useCreateConsumptionRecord()
   const updateRecord = useUpdateConsumptionRecord()
   const deleteRecord = useDeleteConsumptionRecord()
+  const parseUrl = useParseProductUrl()
 
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false)
 
@@ -63,6 +66,7 @@ function RecordCreateForm({ id }: { id?: string }) {
   }, [isNotFound, navigate])
 
   const [type, setType] = useState<RecordType>(editingRecord?.type ?? 'consume')
+  const [productUrl, setProductUrl] = useState('')
   const [title, setTitle] = useState(editingRecord?.title ?? '')
   const [amount, setAmount] = useState(editingRecord?.amount ?? 0)
   const [category, setCategory] = useState<Category>(
@@ -76,26 +80,36 @@ function RecordCreateForm({ id }: { id?: string }) {
 
   const submitError = createRecord.isError || updateRecord.isError
 
+  const handleParseUrl = () => {
+    if (!productUrl.trim()) return
+    parseUrl.mutate(productUrl, {
+      onSuccess: (data) => {
+        setTitle(data.productName)
+        setAmount(data.price)
+      },
+    })
+  }
+
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
     if (!isValid) return
 
     if (isEditMode && id) {
       updateRecord.mutate(
-        { id, input: { type, productName: title, price: amount, category, reason } },
+        { id, input: { type, productName: title, price: amount, category, reason, productUrl } },
         { onSuccess: () => navigate(`/record/${id}`) },
       )
       return
     }
 
     if (type === 'consume') {
-      const draft: RecordDraft = { title, amount, category, reason }
+      const draft: RecordDraft = { title, amount, category, reason, productUrl }
       navigate('/record/intervention', { state: { draft } })
       return
     }
 
     createRecord.mutate(
-      { type, productName: title, price: amount, category, reason },
+      { type, productName: title, price: amount, category, reason, productUrl },
       { onSuccess: () => navigate('/record') },
     )
   }
@@ -129,16 +143,28 @@ function RecordCreateForm({ id }: { id?: string }) {
 
       <form className={styles.form} onSubmit={handleSubmit}>
         <div className={styles.field}>
-          <label htmlFor="title" className={styles.label}>
-            이름
+          <label htmlFor="productUrl" className={styles.label}>
+            상품 URL (선택)
           </label>
-          <input
-            id="title"
-            className={styles.textInput}
-            placeholder="예: 투썸플레이스 신봉점"
-            value={title}
-            onChange={(event) => setTitle(event.target.value)}
-          />
+          <div className={styles.urlRow}>
+            <input
+              id="productUrl"
+              className={`${styles.textInput} ${styles.urlInput}`}
+              placeholder="https://..."
+              value={productUrl}
+              onChange={(event) => setProductUrl(event.target.value)}
+            />
+            <button
+              type="button"
+              className={styles.urlButton}
+              disabled={!productUrl.trim() || parseUrl.isPending}
+              onClick={handleParseUrl}
+            >
+              {parseUrl.isPending ? '불러오는 중' : '불러오기'}
+            </button>
+          </div>
+          {parseUrl.isError && <p className={styles.errorText}>URL을 불러오는 데 실패했습니다.</p>}
+          {parseUrl.isSuccess && <p className={styles.successText}>상품 정보를 불러왔습니다.</p>}
         </div>
 
         <div className={styles.field}>
@@ -150,6 +176,19 @@ function RecordCreateForm({ id }: { id?: string }) {
             className={styles.amountWrapper}
             value={amount}
             onChange={setAmount}
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label htmlFor="title" className={styles.label}>
+            상품명
+          </label>
+          <input
+            id="title"
+            className={styles.textInput}
+            placeholder="예: 투썸플레이스 신봉점"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
           />
         </div>
 


### PR DESCRIPTION
## 📌 작업 내용

### 입력/수정/삭제 (#94)
- `POST /api/v1/consumption-records` (입력), `PUT /api/v1/consumption-records/{id}` (수정), `DELETE /api/v1/consumption-records/{id}` (삭제) 연동
- `consumptionRecordApi.ts`에 `create`/`update`/`remove` 메서드 추가
- 카테고리 라벨 → `category_code` 매핑 추가 (실제 백엔드에 값 하나씩 확인해서 9개 전부 확정: FASHION/BEAUTY/FOOD_SNACK/CAFE_DESSERT/HOBBY_GOODS/ELECTRONICS/HEALTH_FITNESS/TRAVEL/ETC)
- `useCreateConsumptionRecord`/`useUpdateConsumptionRecord`/`useDeleteConsumptionRecord` mutation 훅 추가
- `RecordCreatePage`
  - 수정 모드 프리필을 `MOCK_RECORDS` 대신 실제 상세 조회 API로 교체
  - 헤더에 삭제 아이콘 추가(수정 모드일 때만, 상세 페이지 수정 버튼과 동일 위치) + `ConfirmDialog`로 확인 후 삭제
  - "참았어요" 선택 시 제출과 동시에 바로 생성
- **"샀어요" 플로우 실제 연결**: 상품명/금액/카테고리/사유가 개입 질문 페이지로 전달되지 않고 사라지던 문제와, `RiskResultPage`의 "안 살게요"/"그래도 살게요" 버튼이 아무것도 저장하지 않던 문제를 해결했습니다. `RecordCreatePage → RecordInterventionPage → RiskResultPage`까지 `navigate` state로 폼 데이터를 그대로 전달해서, 최종 버튼 클릭 시 실제로 소비 기록이 생성되도록 연결했습니다.


### 상품 URL 파싱 및 입력 필드 개편 (#96)
- `POST /api/v1/product-url/parse` 연동
- `RecordCreatePage`에 "상품 URL" 입력 + 불러오기 버튼 추가
- 필드 순서를 URL → 금액 → 상품명 → 카테고리 → 사고 싶은 이유로 재배치, "이름" 라벨을 "상품명"으로 변경
- 파싱 성공 시 상품명/금액 자동 채움, 실패 시 에러 메시지 노출
- 생성/수정 요청에 `productUrl` 포함하도록 연동
</br>

## 📷 스크린 샷
</br>

## ⚠️ 참고 사항

- 개입 질문(`GET /intervention-questions`)과 위험도 계산(`POST /interventions/risk-score`) API는 이번 범위에서 제외하고 별도 이슈(#99, #100)로 분리했습니다. 그래서 지금은 질문/점수 계산이 여전히 프론트 로컬 로직(하드코딩)이고, 생성 요청에 `interventionAnswers`는 담지 않습니다 (실제 질문 ID가 없어 백엔드가 404를 낼 수 있음).
- `workHoursNeeded`(아르바이트 필요 시간)는 시급 계산 기능 자체가 없어 여전히 하드코딩(26시간)이며 백엔드로 전송하지 않습니다.
- 실제 배포된 백엔드에 로그인해서 참았어요 즉시생성 → 수정 → 삭제 → 샀어요→개입질문→위험도결과→최종생성까지 전체 플로우를 직접 확인했습니다.
</br>

## 🔗 관련 이슈
Closes #94
Closes #96
</br>

