### PR TITLE
✨ [Feature] 알림 API 연동

### DIFF
--- a/src/features/notification/api/notificationApi.ts
+++ b/src/features/notification/api/notificationApi.ts
@@ -19,6 +19,24 @@ export interface NotificationSettingsResponse {
   retrial: boolean
 }
 
+const NOTIFICATION_SETTINGS_URL = '/api/v1/users/me/notification-settings'
+
+interface NotificationSettingsResult {
+  notifyGeneralEnabled: boolean
+  notifyGoalEnabled: boolean
+  notifyTemptationEnabled: boolean
+  notifyPushEnabled: boolean
+}
+
+function adaptSettings(result: NotificationSettingsResult): NotificationSettingsResponse {
+  return {
+    all: result.notifyPushEnabled,
+    general: result.notifyGeneralEnabled,
+    goal: result.notifyGoalEnabled,
+    retrial: result.notifyTemptationEnabled,
+  }
+}
+
 // ─── 어댑터 유틸 ──────────────────────────────────────────────────────────────
 
 const TYPE_MAP = {
@@ -64,7 +82,7 @@ function formatTime(isoString: string): string {
 function adapt(n: NotificationResult): NotificationItem {
   const { title, description } = CONTENT_MAP[n.notificationType]
   return {
-    id: Number(n.id),
+    id: n.id,
     type: TYPE_MAP[n.notificationType],
     iconVariant: ICON_MAP[n.notificationType],
     title,
@@ -84,7 +102,7 @@ export const notificationApi = {
     return data.data.map(adapt)
   },
 
-  readOne: async (id: number): Promise<void> => {
+  readOne: async (id: string): Promise<void> => {
     await client.patch(`/api/v1/notifications/${id}/read`)
   },
 
@@ -92,48 +110,32 @@ export const notificationApi = {
     await client.patch('/api/v1/notifications/read-all')
   },
 
+  getSettings: async (): Promise<NotificationSettingsResponse> => {
+    const { data } = await client.get<{ data: NotificationSettingsResult }>(
+      NOTIFICATION_SETTINGS_URL,
+    )
+    return adaptSettings(data.data)
+  },
+
   updateAllSetting: async (enabled: boolean): Promise<NotificationSettingsResponse> => {
-    const { data } = await client.patch<{
-      data: {
-        notifyGeneralEnabled: boolean
-        notifyGoalEnabled: boolean
-        notifyTemptationEnabled: boolean
-        notifyPushEnabled: boolean
-      }
-    }>('/api/v1/users/me/notification-settings', { notifyPushEnabled: enabled })
-    return {
-      all: data.data.notifyPushEnabled,
-      general: data.data.notifyGeneralEnabled,
-      goal: data.data.notifyGoalEnabled,
-      retrial: data.data.notifyTemptationEnabled,
-    }
+    const { data } = await client.patch<{ data: NotificationSettingsResult }>(
+      NOTIFICATION_SETTINGS_URL,
+      { notifyPushEnabled: enabled },
+    )
+    return adaptSettings(data.data)
   },
 
   updateSubSettings: async (
     settings: Omit<NotificationSettingsResponse, 'all'>,
   ): Promise<NotificationSettingsResponse> => {
-    const { data } = await client.patch<{
-      data: {
-        notifyGeneralEnabled: boolean
-        notifyGoalEnabled: boolean
-        notifyTemptationEnabled: boolean
-        notifyPushEnabled: boolean
-      }
-    }>('/api/v1/users/me/notification-settings', {
-      notifyGeneralEnabled: settings.general,
-      notifyGoalEnabled: settings.goal,
-      notifyTemptationEnabled: settings.retrial,
-    })
-    return {
-      all: data.data.notifyPushEnabled,
-      general: data.data.notifyGeneralEnabled,
-      goal: data.data.notifyGoalEnabled,
-      retrial: data.data.notifyTemptationEnabled,
-    }
-  },
-
-  // TODO: 설정 조회 GET API가 없어 임시로 전부 켜진 값을 반환합니다. API 추가 후 교체 필요.
-  getSettings: async (): Promise<NotificationSettingsResponse> => {
-    return { all: true, general: true, goal: true, retrial: true }
+    const { data } = await client.patch<{ data: NotificationSettingsResult }>(
+      NOTIFICATION_SETTINGS_URL,
+      {
+        notifyGeneralEnabled: settings.general,
+        notifyGoalEnabled: settings.goal,
+        notifyTemptationEnabled: settings.retrial,
+      },
+    )
+    return adaptSettings(data.data)
   },
 }

--- a/src/features/notification/api/notificationApi.ts
+++ b/src/features/notification/api/notificationApi.ts
@@ -39,6 +39,13 @@ const CONTENT_MAP = {
   GENERAL: { title: '일반 알림', description: '서비스 소식을 확인하세요.' },
 } as const
 
+// 서버 시각(createdAt)은 KST 기준 계약이므로, 브라우저 로컬 시간대와 무관하게 항상 서울 기준으로 표기합니다.
+const KST_MONTH_DAY = new Intl.DateTimeFormat('ko-KR', {
+  timeZone: 'Asia/Seoul',
+  month: 'numeric',
+  day: 'numeric',
+})
+
 function formatTime(isoString: string): string {
   const date = new Date(isoString)
   const diffMins = Math.floor((Date.now() - date.getTime()) / 60000)
@@ -48,7 +55,10 @@ function formatTime(isoString: string): string {
   if (diffHours < 24) return `${diffHours}시간 전`
   const diffDays = Math.floor(diffHours / 24)
   if (diffDays < 7) return `${diffDays}일 전`
-  return `${date.getMonth() + 1}월 ${date.getDate()}일`
+
+  const parts = KST_MONTH_DAY.formatToParts(date)
+  const get = (type: string) => parts.find((part) => part.type === type)?.value ?? ''
+  return `${get('month')}월 ${get('day')}일`
 }
 
 function adapt(n: NotificationResult): NotificationItem {
@@ -122,15 +132,8 @@ export const notificationApi = {
     }
   },
 
+  // TODO: 설정 조회 GET API가 없어 임시로 전부 켜진 값을 반환합니다. API 추가 후 교체 필요.
   getSettings: async (): Promise<NotificationSettingsResponse> => {
     return { all: true, general: true, goal: true, retrial: true }
-  },
-
-  updateSettings: async (settings: NotificationSettingsResponse): Promise<void> => {
-    await client.patch('/api/v1/users/me/notification-settings', {
-      notifyGeneralEnabled: settings.general,
-      notifyGoalEnabled: settings.goal,
-      notifyTemptationEnabled: settings.retrial,
-    })
   },
 }

--- a/src/features/notification/api/notificationApi.ts
+++ b/src/features/notification/api/notificationApi.ts
@@ -121,4 +121,16 @@ export const notificationApi = {
       retrial: data.data.notifyTemptationEnabled,
     }
   },
+
+  getSettings: async (): Promise<NotificationSettingsResponse> => {
+    return { all: true, general: true, goal: true, retrial: true }
+  },
+
+  updateSettings: async (settings: NotificationSettingsResponse): Promise<void> => {
+    await client.patch('/api/v1/users/me/notification-settings', {
+      notifyGeneralEnabled: settings.general,
+      notifyGoalEnabled: settings.goal,
+      notifyTemptationEnabled: settings.retrial,
+    })
+  },
 }

--- a/src/features/notification/api/notificationApi.ts
+++ b/src/features/notification/api/notificationApi.ts
@@ -1,13 +1,15 @@
+import client from '@/api/client'
 import type { NotificationItem } from '../components/NotificationCard'
 
-// TODO: 백엔드 응답 타입으로 교체
-export interface NotificationResponse {
-  id: number
-  type: 'GENERAL' | 'GOAL' | 'RETRIAL'
-  title: string
-  body: string
-  createdAt: string
+// ─── API 응답 타입 ────────────────────────────────────────────────────────────
+
+interface NotificationResult {
+  id: string
+  notificationType: 'TEMPTATION' | 'GOAL' | 'GENERAL'
   isRead: boolean
+  readAt: string | null
+  wishlistItemId: string | null
+  createdAt: string
 }
 
 export interface NotificationSettingsResponse {
@@ -17,103 +19,106 @@ export interface NotificationSettingsResponse {
   retrial: boolean
 }
 
-// ─── Mock 데이터 (API 연결 후 제거) ────────────────────────────────────────
-// id가 클수록 최신 알림 (최신순 정렬 기준: b.id - a.id)
-let mockNotifications: NotificationItem[] = [
-  {
-    id: 1,
-    type: '유혹관리',
-    iconVariant: 'heart',
-    title: '새로운 유혹이 추가됨',
-    description: "'미스치프 후드티'를 위시리스트에 담았습니다. 1일 뒤에 다시 물어볼게요!",
-    time: '4월 28일',
-    isRead: true,
-  },
-  {
-    id: 2,
-    type: '유혹관리',
-    iconVariant: 'heart',
-    title: '새로운 유혹이 추가됨',
-    description: "'스타벅스 텀블러'를 위시리스트에 담았습니다. 1일 뒤에 다시 물어볼게요!",
-    time: '4월 30일',
-    isRead: true,
-  },
-  {
-    id: 3,
-    type: '일반',
-    iconVariant: 'calendar',
-    title: '4월 월간 리포트 도착',
-    description: '지난달 나의 소비 통제력 점수를 확인해 보세요.',
-    time: '1시간 전',
-    isRead: true,
-  },
-  {
-    id: 4,
-    type: '목표현황',
-    iconVariant: 'check',
-    title: '목표 달성률 70% 돌파!',
-    description: '제주도 항공권까지 얼마 남지 않았어요! 조금만 더 힘내세요.',
-    time: '방금 전',
-    isRead: false,
-  },
-  {
-    id: 5,
-    type: '유혹관리',
-    iconVariant: 'lightning',
-    title: '결단의 시간이 왔어요!',
-    description: "'아이폰 17 Pro' 대기 시간이 끝났어요. 아직도 사고 싶으신가요?",
-    time: '방금 전',
-    isRead: false,
-  },
-]
+// ─── 어댑터 유틸 ──────────────────────────────────────────────────────────────
 
-let mockSettings: NotificationSettingsResponse = {
-  all: true,
-  general: true,
-  goal: true,
-  retrial: true,
+const TYPE_MAP = {
+  TEMPTATION: '유혹관리',
+  GOAL: '목표현황',
+  GENERAL: '일반',
+} as const
+
+const ICON_MAP = {
+  TEMPTATION: 'lightning',
+  GOAL: 'check',
+  GENERAL: 'calendar',
+} as const
+
+const CONTENT_MAP = {
+  TEMPTATION: { title: '유혹 관리 알림', description: '위시리스트 관련 알림이 도착했습니다.' },
+  GOAL: { title: '목표 현황 알림', description: '절약 목표 진행 상황을 확인하세요.' },
+  GENERAL: { title: '일반 알림', description: '서비스 소식을 확인하세요.' },
+} as const
+
+function formatTime(isoString: string): string {
+  const date = new Date(isoString)
+  const diffMins = Math.floor((Date.now() - date.getTime()) / 60000)
+  if (diffMins < 1) return '방금 전'
+  if (diffMins < 60) return `${diffMins}분 전`
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours < 24) return `${diffHours}시간 전`
+  const diffDays = Math.floor(diffHours / 24)
+  if (diffDays < 7) return `${diffDays}일 전`
+  return `${date.getMonth() + 1}월 ${date.getDate()}일`
 }
-// ──────────────────────────────────────────────────────────────────────────
+
+function adapt(n: NotificationResult): NotificationItem {
+  const { title, description } = CONTENT_MAP[n.notificationType]
+  return {
+    id: Number(n.id),
+    type: TYPE_MAP[n.notificationType],
+    iconVariant: ICON_MAP[n.notificationType],
+    title,
+    description,
+    time: formatTime(n.createdAt),
+    isRead: n.isRead,
+  }
+}
+
+// ─── API ──────────────────────────────────────────────────────────────────────
 
 export const notificationApi = {
-  getList: async (): Promise<NotificationItem[]> => {
-    // TODO: API 연결 시 아래 두 줄로 교체하고 mockNotifications 제거
-    // const { data } = await client.get<NotificationResponse[]>('/notifications')
-    // return data.map(adaptNotification)
-    return mockNotifications
+  getList: async (type = 'ALL', sort = 'LATEST'): Promise<NotificationItem[]> => {
+    const { data } = await client.get<{ data: NotificationResult[] }>('/api/v1/notifications', {
+      params: { type, sort },
+    })
+    return data.data.map(adapt)
   },
 
-  deleteOne: async (id: number): Promise<void> => {
-    // TODO: API 연결 시 아래 줄로 교체하고 mock 제거
-    // await client.delete(`/notifications/${id}`)
-    mockNotifications = mockNotifications.filter((n) => n.id !== id)
+  readOne: async (id: number): Promise<void> => {
+    await client.patch(`/api/v1/notifications/${id}/read`)
   },
 
-  getSettings: async (): Promise<NotificationSettingsResponse> => {
-    // TODO: API 연결 시 아래 두 줄로 교체하고 mockSettings 제거
-    // const { data } = await client.get<NotificationSettingsResponse>('/notifications/settings')
-    // return data
-    return { ...mockSettings }
+  readAll: async (): Promise<void> => {
+    await client.patch('/api/v1/notifications/read-all')
   },
 
-  updateSettings: async (settings: NotificationSettingsResponse): Promise<void> => {
-    // TODO: API 연결 시 아래 줄로 교체하고 mock 제거
-    // await client.put('/notifications/settings', settings)
-    mockSettings = { ...settings }
+  updateAllSetting: async (enabled: boolean): Promise<NotificationSettingsResponse> => {
+    const { data } = await client.patch<{
+      data: {
+        notifyGeneralEnabled: boolean
+        notifyGoalEnabled: boolean
+        notifyTemptationEnabled: boolean
+        notifyPushEnabled: boolean
+      }
+    }>('/api/v1/users/me/notification-settings', { notifyPushEnabled: enabled })
+    return {
+      all: data.data.notifyPushEnabled,
+      general: data.data.notifyGeneralEnabled,
+      goal: data.data.notifyGoalEnabled,
+      retrial: data.data.notifyTemptationEnabled,
+    }
+  },
+
+  updateSubSettings: async (
+    settings: Omit<NotificationSettingsResponse, 'all'>,
+  ): Promise<NotificationSettingsResponse> => {
+    const { data } = await client.patch<{
+      data: {
+        notifyGeneralEnabled: boolean
+        notifyGoalEnabled: boolean
+        notifyTemptationEnabled: boolean
+        notifyPushEnabled: boolean
+      }
+    }>('/api/v1/users/me/notification-settings', {
+      notifyGeneralEnabled: settings.general,
+      notifyGoalEnabled: settings.goal,
+      notifyTemptationEnabled: settings.retrial,
+    })
+    return {
+      all: data.data.notifyPushEnabled,
+      general: data.data.notifyGeneralEnabled,
+      goal: data.data.notifyGoalEnabled,
+      retrial: data.data.notifyTemptationEnabled,
+    }
   },
 }
-
-// TODO: 백엔드 타입 → 프론트 타입 변환 (API 연결 시 주석 해제)
-// function adaptNotification(item: NotificationResponse): NotificationItem {
-//   const TYPE_MAP = { GENERAL: '일반', GOAL: '목표현황', RETRIAL: '유혹관리' } as const
-//   const ICON_MAP = { GENERAL: 'calendar', GOAL: 'check', RETRIAL: 'lightning' } as const
-//   return {
-//     id: item.id,
-//     type: TYPE_MAP[item.type],
-//     iconVariant: ICON_MAP[item.type],
-//     title: item.title,
-//     description: item.body,
-//     time: formatTime(item.createdAt),  // TODO: formatTime 유틸 구현
-//     isRead: item.isRead,
-//   }
-// }

--- a/src/features/notification/components/NotificationCard.tsx
+++ b/src/features/notification/components/NotificationCard.tsx
@@ -14,7 +14,8 @@ import styles from './NotificationCard.module.css'
 import type { FilterType } from './FilterTabs'
 
 export interface NotificationItem {
-  id: number
+  // 서버가 id를 문자열로 내려주므로 변환 없이 그대로 사용합니다(정밀도 손실·NaN 방지).
+  id: string
   type: Exclude<FilterType, '전체'>
   iconVariant: 'lightning' | 'check' | 'calendar' | 'heart'
   title: string
@@ -38,7 +39,7 @@ const ICON_CONFIG: Record<
 }
 
 interface Props extends NotificationItem {
-  onRead: (id: number) => void
+  onRead: (id: string) => void
 }
 
 export default function NotificationCard({

--- a/src/features/notification/components/NotificationSettingsSheet.module.css
+++ b/src/features/notification/components/NotificationSettingsSheet.module.css
@@ -45,6 +45,13 @@
   margin: 0;
 }
 
+.errorText {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-sub-red, #e5484d);
+}
+
 .masterItem {
   display: flex;
   align-items: center;

--- a/src/features/notification/components/NotificationSettingsSheet.test.tsx
+++ b/src/features/notification/components/NotificationSettingsSheet.test.tsx
@@ -2,17 +2,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import NotificationSettingsSheet from './NotificationSettingsSheet'
-import { useNotificationSettings, useUpdateNotificationSettings } from '../hooks/useNotifications'
+import {
+  useNotificationSettings,
+  useUpdateAllSetting,
+  useUpdateSubSettings,
+} from '../hooks/useNotifications'
 
 vi.mock('../hooks/useNotifications', () => ({
   useNotificationSettings: vi.fn(),
-  useUpdateNotificationSettings: vi.fn(),
+  useUpdateAllSetting: vi.fn(),
+  useUpdateSubSettings: vi.fn(),
 }))
 
 const mockedUseNotificationSettings = vi.mocked(useNotificationSettings)
-const mockedUseUpdateNotificationSettings = vi.mocked(useUpdateNotificationSettings)
+const mockedUseUpdateAllSetting = vi.mocked(useUpdateAllSetting)
+const mockedUseUpdateSubSettings = vi.mocked(useUpdateSubSettings)
 
-const mutate = vi.fn()
+const updateAll = vi.fn()
+const updateSub = vi.fn()
 
 function mockServerSettings(data: {
   all: boolean
@@ -25,12 +32,22 @@ function mockServerSettings(data: {
   >)
 }
 
+function mockMutations({ isPending = false } = {}) {
+  mockedUseUpdateAllSetting.mockReturnValue({
+    mutate: updateAll,
+    isPending,
+  } as unknown as ReturnType<typeof useUpdateAllSetting>)
+  mockedUseUpdateSubSettings.mockReturnValue({
+    mutate: updateSub,
+    isPending: false,
+  } as unknown as ReturnType<typeof useUpdateSubSettings>)
+}
+
 describe('NotificationSettingsSheet 전체 알림 마스터 토글', () => {
   beforeEach(() => {
-    mutate.mockClear()
-    mockedUseUpdateNotificationSettings.mockReturnValue({ mutate } as unknown as ReturnType<
-      typeof useUpdateNotificationSettings
-    >)
+    updateAll.mockClear()
+    updateSub.mockClear()
+    mockMutations()
     mockServerSettings({ all: true, general: true, goal: true, retrial: true })
   })
 
@@ -47,10 +64,22 @@ describe('NotificationSettingsSheet 전체 알림 마스터 토글', () => {
     await user.click(screen.getByRole('button', { name: '유혹 관리 알림 끄기' }))
 
     expect(screen.getByRole('button', { name: '전체 알림 켜기' })).toBeInTheDocument()
-    expect(mutate).toHaveBeenCalledWith({ general: true, goal: true, retrial: false, all: false })
+    expect(updateSub).toHaveBeenCalledWith(
+      { general: true, goal: true, retrial: false },
+      expect.anything(),
+    )
   })
 
-  it('전체 알림을 끄면 하위 세 항목이 모두 꺼진다', async () => {
+  it('하위 항목 변경은 전체 알림 API를 호출하지 않는다', async () => {
+    const user = userEvent.setup()
+    render(<NotificationSettingsSheet onClose={() => {}} />)
+
+    await user.click(screen.getByRole('button', { name: '유혹 관리 알림 끄기' }))
+
+    expect(updateAll).not.toHaveBeenCalled()
+  })
+
+  it('전체 알림을 끄면 하위 세 항목이 모두 꺼지고 전체 알림 API만 호출한다', async () => {
     const user = userEvent.setup()
     render(<NotificationSettingsSheet onClose={() => {}} />)
 
@@ -59,7 +88,8 @@ describe('NotificationSettingsSheet 전체 알림 마스터 토글', () => {
     expect(screen.getByRole('button', { name: '유혹 관리 알림 켜기' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '목표 현황 알림 켜기' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '일반 알림 켜기' })).toBeInTheDocument()
-    expect(mutate).toHaveBeenCalledWith({ general: false, goal: false, retrial: false, all: false })
+    expect(updateAll).toHaveBeenCalledWith(false, expect.anything())
+    expect(updateSub).not.toHaveBeenCalled()
   })
 
   it('일부만 켜진 상태에서 전체 알림을 누르면 하위 항목이 모두 켜진다', async () => {
@@ -69,6 +99,28 @@ describe('NotificationSettingsSheet 전체 알림 마스터 토글', () => {
 
     await user.click(screen.getByRole('button', { name: '전체 알림 켜기' }))
 
-    expect(mutate).toHaveBeenCalledWith({ general: true, goal: true, retrial: true, all: true })
+    expect(updateAll).toHaveBeenCalledWith(true, expect.anything())
+  })
+
+  it('저장 요청이 진행 중이면 토글이 잠겨 추가 요청을 보내지 않는다', async () => {
+    mockMutations({ isPending: true })
+    const user = userEvent.setup()
+    render(<NotificationSettingsSheet onClose={() => {}} />)
+
+    await user.click(screen.getByRole('button', { name: '유혹 관리 알림 끄기' }))
+
+    expect(updateSub).not.toHaveBeenCalled()
+    expect(updateAll).not.toHaveBeenCalled()
+  })
+
+  it('저장에 실패하면 토글이 이전 상태로 되돌아가고 안내 문구가 뜬다', async () => {
+    updateSub.mockImplementation((_settings, options) => options?.onError?.(new Error('failed')))
+    const user = userEvent.setup()
+    render(<NotificationSettingsSheet onClose={() => {}} />)
+
+    await user.click(screen.getByRole('button', { name: '유혹 관리 알림 끄기' }))
+
+    expect(screen.getByRole('button', { name: '유혹 관리 알림 끄기' })).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('설정을 저장하지 못했어요')
   })
 })

--- a/src/features/notification/components/NotificationSettingsSheet.tsx
+++ b/src/features/notification/components/NotificationSettingsSheet.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect } from 'react'
-import { useNotificationSettings, useUpdateNotificationSettings } from '../hooks/useNotifications'
+import {
+  useNotificationSettings,
+  useUpdateAllSetting,
+  useUpdateSubSettings,
+} from '../hooks/useNotifications'
 import styles from './NotificationSettingsSheet.module.css'
 
 const SETTINGS_LIST = [
@@ -31,13 +35,18 @@ interface Props {
 
 export default function NotificationSettingsSheet({ onClose }: Props) {
   const { data: serverSettings } = useNotificationSettings()
-  const { mutate } = useUpdateNotificationSettings()
+  const { mutate: updateAll, isPending: isUpdatingAll } = useUpdateAllSetting()
+  const { mutate: updateSub, isPending: isUpdatingSub } = useUpdateSubSettings()
+
+  // 서버가 동시 요청에 409를 반환하므로, 요청이 끝날 때까지 토글을 잠급니다.
+  const isSaving = isUpdatingAll || isUpdatingSub
 
   const [enabled, setEnabled] = useState<SubSettings>({
     general: true,
     goal: true,
     retrial: true,
   })
+  const [saveError, setSaveError] = useState(false)
 
   useEffect(() => {
     if (serverSettings) {
@@ -49,18 +58,29 @@ export default function NotificationSettingsSheet({ onClose }: Props) {
 
   const allOn = enabled.general && enabled.goal && enabled.retrial
 
-  const persist = (next: SubSettings) => {
-    setEnabled(next)
-    mutate({ ...next, all: next.general && next.goal && next.retrial })
+  // 저장에 실패하면 화면만 바뀐 채 서버와 어긋나므로 이전 값으로 되돌립니다.
+  const rollbackTo = (prev: SubSettings) => () => {
+    setEnabled(prev)
+    setSaveError(true)
   }
 
   const toggle = (id: keyof SubSettings) => {
-    persist({ ...enabled, [id]: !enabled[id] })
+    if (isSaving) return
+    const prev = enabled
+    const next = { ...enabled, [id]: !enabled[id] }
+    setEnabled(next)
+    setSaveError(false)
+    updateSub(next, { onError: rollbackTo(prev) })
   }
 
+  // 전체 알림은 notifyPushEnabled만 보내야 하므로 세부 설정과 같은 요청에 담지 않습니다.
   const toggleAll = () => {
+    if (isSaving) return
+    const prev = enabled
     const next = !allOn
-    persist({ general: next, goal: next, retrial: next })
+    setEnabled({ general: next, goal: next, retrial: next })
+    setSaveError(false)
+    updateAll(next, { onError: rollbackTo(prev) })
   }
 
   return (
@@ -69,11 +89,18 @@ export default function NotificationSettingsSheet({ onClose }: Props) {
         <div className={styles.handle} />
         <h2 className={styles.title}>어떤 알림을 받을까요?</h2>
 
+        {saveError && (
+          <p className={styles.errorText} role="alert">
+            설정을 저장하지 못했어요. 잠시 후 다시 시도해주세요.
+          </p>
+        )}
+
         <div className={styles.masterItem}>
           <span className={styles.masterLabel}>전체 알림</span>
           <button
             className={`${styles.toggle} ${allOn ? styles.on : ''}`}
             onClick={toggleAll}
+            disabled={isSaving}
             aria-label={`전체 알림 ${allOn ? '끄기' : '켜기'}`}
           >
             <span className={styles.toggleThumb} />
@@ -91,6 +118,7 @@ export default function NotificationSettingsSheet({ onClose }: Props) {
               <button
                 className={`${styles.toggle} ${enabled[item.id] ? styles.on : ''}`}
                 onClick={() => toggle(item.id)}
+                disabled={isSaving}
                 aria-label={`${item.label} ${enabled[item.id] ? '끄기' : '켜기'}`}
               >
                 <span className={styles.toggleThumb} />

--- a/src/features/notification/components/NotificationSettingsSheet.tsx
+++ b/src/features/notification/components/NotificationSettingsSheet.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { notificationApi } from '../api/notificationApi'
+import { useState, useEffect } from 'react'
+import { useNotificationSettings, useUpdateNotificationSettings } from '../hooks/useNotifications'
 import styles from './NotificationSettingsSheet.module.css'
 
 const SETTINGS_LIST = [
@@ -30,24 +30,37 @@ interface Props {
 }
 
 export default function NotificationSettingsSheet({ onClose }: Props) {
+  const { data: serverSettings } = useNotificationSettings()
+  const { mutate } = useUpdateNotificationSettings()
+
   const [enabled, setEnabled] = useState<SubSettings>({
     general: true,
     goal: true,
     retrial: true,
   })
-  const [allOn, setAllOn] = useState(true)
 
-  const toggleAll = () => {
-    const next = !allOn
-    setAllOn(next)
-    setEnabled({ general: next, goal: next, retrial: next })
-    notificationApi.updateAllSetting(next).catch(() => {})
+  useEffect(() => {
+    if (serverSettings) {
+      const { general, goal, retrial } = serverSettings
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setEnabled({ general, goal, retrial })
+    }
+  }, [serverSettings])
+
+  const allOn = enabled.general && enabled.goal && enabled.retrial
+
+  const persist = (next: SubSettings) => {
+    setEnabled(next)
+    mutate({ ...next, all: next.general && next.goal && next.retrial })
   }
 
   const toggle = (id: keyof SubSettings) => {
-    const next = { ...enabled, [id]: !enabled[id] }
-    setEnabled(next)
-    notificationApi.updateSubSettings(next).catch(() => {})
+    persist({ ...enabled, [id]: !enabled[id] })
+  }
+
+  const toggleAll = () => {
+    const next = !allOn
+    persist({ general: next, goal: next, retrial: next })
   }
 
   return (

--- a/src/features/notification/components/NotificationSettingsSheet.tsx
+++ b/src/features/notification/components/NotificationSettingsSheet.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react'
-import { useNotificationSettings, useUpdateNotificationSettings } from '../hooks/useNotifications'
+import { useState } from 'react'
+import { notificationApi } from '../api/notificationApi'
 import styles from './NotificationSettingsSheet.module.css'
 
 const SETTINGS_LIST = [
@@ -30,38 +30,24 @@ interface Props {
 }
 
 export default function NotificationSettingsSheet({ onClose }: Props) {
-  const { data: serverSettings } = useNotificationSettings()
-  const { mutate: updateSettings } = useUpdateNotificationSettings()
-
   const [enabled, setEnabled] = useState<SubSettings>({
     general: true,
     goal: true,
     retrial: true,
   })
+  const [allOn, setAllOn] = useState(true)
 
-  useEffect(() => {
-    // 서버에서 저장된 알림 설정을 최초 로드 시 로컬 편집 상태로 반영 (사용자가 토글하는 별도 상태이므로 여기서만 동기화)
-    if (serverSettings) {
-      const { general, goal, retrial } = serverSettings
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setEnabled({ general, goal, retrial })
-    }
-  }, [serverSettings])
-
-  const allOn = enabled.general && enabled.goal && enabled.retrial
-
-  const persist = (next: SubSettings) => {
-    setEnabled(next)
-    updateSettings({ ...next, all: next.general && next.goal && next.retrial })
+  const toggleAll = () => {
+    const next = !allOn
+    setAllOn(next)
+    setEnabled({ general: next, goal: next, retrial: next })
+    notificationApi.updateAllSetting(next).catch(() => {})
   }
 
   const toggle = (id: keyof SubSettings) => {
-    persist({ ...enabled, [id]: !enabled[id] })
-  }
-
-  const toggleAll = () => {
-    const nextValue = !allOn
-    persist({ general: nextValue, goal: nextValue, retrial: nextValue })
+    const next = { ...enabled, [id]: !enabled[id] }
+    setEnabled(next)
+    notificationApi.updateSubSettings(next).catch(() => {})
   }
 
   return (

--- a/src/features/notification/hooks/useNotifications.ts
+++ b/src/features/notification/hooks/useNotifications.ts
@@ -1,41 +1,26 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { notificationApi } from '../api/notificationApi'
-import type { NotificationSettingsResponse } from '../api/notificationApi'
 
 const QUERY_KEYS = {
-  list: ['notifications'] as const,
-  settings: ['notifications', 'settings'] as const,
+  list: (type: string, sort: string) => ['notifications', type, sort] as const,
 }
 
-export function useNotifications() {
+export function useNotifications(type = 'ALL', sort = 'LATEST') {
   return useQuery({
-    queryKey: QUERY_KEYS.list,
-    queryFn: notificationApi.getList,
+    queryKey: QUERY_KEYS.list(type, sort),
+    queryFn: () => notificationApi.getList(type, sort),
     staleTime: 1000 * 60,
   })
 }
 
-export function useDeleteNotification() {
-  const queryClient = useQueryClient()
-  return useMutation({
-    mutationFn: notificationApi.deleteOne,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUERY_KEYS.list }),
-  })
+export function useReadNotification() {
+  return useMutation({ mutationFn: notificationApi.readOne })
 }
 
-export function useNotificationSettings() {
-  return useQuery({
-    queryKey: QUERY_KEYS.settings,
-    queryFn: notificationApi.getSettings,
-    staleTime: 1000 * 60 * 5,
-  })
-}
-
-export function useUpdateNotificationSettings() {
+export function useReadAllNotifications() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (settings: NotificationSettingsResponse) =>
-      notificationApi.updateSettings(settings),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUERY_KEYS.settings }),
+    mutationFn: notificationApi.readAll,
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['notifications'] }),
   })
 }

--- a/src/features/notification/hooks/useNotifications.ts
+++ b/src/features/notification/hooks/useNotifications.ts
@@ -1,8 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { notificationApi } from '../api/notificationApi'
+import type { NotificationSettingsResponse } from '../api/notificationApi'
 
 const QUERY_KEYS = {
   list: (type: string, sort: string) => ['notifications', type, sort] as const,
+  settings: ['notifications', 'settings'] as const,
 }
 
 export function useNotifications(type = 'ALL', sort = 'LATEST') {
@@ -22,5 +24,22 @@ export function useReadAllNotifications() {
   return useMutation({
     mutationFn: notificationApi.readAll,
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['notifications'] }),
+  })
+}
+
+export function useNotificationSettings() {
+  return useQuery({
+    queryKey: QUERY_KEYS.settings,
+    queryFn: notificationApi.getSettings,
+    staleTime: 1000 * 60 * 5,
+  })
+}
+
+export function useUpdateNotificationSettings() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (settings: NotificationSettingsResponse) =>
+      notificationApi.updateSettings(settings),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUERY_KEYS.settings }),
   })
 }

--- a/src/features/notification/hooks/useNotifications.ts
+++ b/src/features/notification/hooks/useNotifications.ts
@@ -32,10 +32,24 @@ export function useReadAllNotifications() {
   })
 }
 
+// 조회 API 배포 전에는 404가 날 수 있어, 실패해도 시트가 열리도록 기본값으로 폴백합니다.
+const DEFAULT_SETTINGS: NotificationSettingsResponse = {
+  all: true,
+  general: true,
+  goal: true,
+  retrial: true,
+}
+
 export function useNotificationSettings() {
   return useQuery({
     queryKey: QUERY_KEYS.settings,
-    queryFn: notificationApi.getSettings,
+    queryFn: async () => {
+      try {
+        return await notificationApi.getSettings()
+      } catch {
+        return DEFAULT_SETTINGS
+      }
+    },
     staleTime: 1000 * 60 * 5,
   })
 }

--- a/src/features/notification/hooks/useNotifications.ts
+++ b/src/features/notification/hooks/useNotifications.ts
@@ -1,10 +1,14 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
 import { notificationApi } from '../api/notificationApi'
 import type { NotificationSettingsResponse } from '../api/notificationApi'
 
 const QUERY_KEYS = {
+  // 목록은 필터/정렬별로 나뉘므로 prefix 단위 무효화를 위해 'notifications'를 공유합니다.
+  lists: ['notifications'] as const,
   list: (type: string, sort: string) => ['notifications', type, sort] as const,
-  settings: ['notifications', 'settings'] as const,
+  // 설정은 목록 무효화에 휩쓸리지 않도록 별도 prefix를 씁니다.
+  settings: ['notification-settings'] as const,
 }
 
 export function useNotifications(type = 'ALL', sort = 'LATEST') {
@@ -19,8 +23,8 @@ export function useReadNotification() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: notificationApi.readOne,
-    // 읽음 상태는 필터/정렬별 목록 캐시에 모두 걸쳐 있어 prefix 단위로 무효화합니다.
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['notifications'] }),
+    // 읽음 상태는 필터/정렬별 목록 캐시에 모두 걸쳐 있어 목록 prefix 단위로 무효화합니다.
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lists }),
   })
 }
 
@@ -28,11 +32,12 @@ export function useReadAllNotifications() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: notificationApi.readAll,
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['notifications'] }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lists }),
   })
 }
 
-// 조회 API 배포 전에는 404가 날 수 있어, 실패해도 시트가 열리도록 기본값으로 폴백합니다.
+// TODO: 조회 API(BE #89)가 배포되면 아래 404 폴백을 제거하세요.
+// 미배포 구간에만 쓰는 임시 처리이며, 401/500 등 실제 오류는 그대로 던져 재시도·에러 상태가 동작하게 둡니다.
 const DEFAULT_SETTINGS: NotificationSettingsResponse = {
   all: true,
   general: true,
@@ -46,8 +51,9 @@ export function useNotificationSettings() {
     queryFn: async () => {
       try {
         return await notificationApi.getSettings()
-      } catch {
-        return DEFAULT_SETTINGS
+      } catch (error) {
+        if (isAxiosError(error) && error.response?.status === 404) return DEFAULT_SETTINGS
+        throw error
       }
     },
     staleTime: 1000 * 60 * 5,

--- a/src/features/notification/hooks/useNotifications.ts
+++ b/src/features/notification/hooks/useNotifications.ts
@@ -16,7 +16,12 @@ export function useNotifications(type = 'ALL', sort = 'LATEST') {
 }
 
 export function useReadNotification() {
-  return useMutation({ mutationFn: notificationApi.readOne })
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: notificationApi.readOne,
+    // 읽음 상태는 필터/정렬별 목록 캐시에 모두 걸쳐 있어 prefix 단위로 무효화합니다.
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['notifications'] }),
+  })
 }
 
 export function useReadAllNotifications() {
@@ -35,11 +40,24 @@ export function useNotificationSettings() {
   })
 }
 
-export function useUpdateNotificationSettings() {
+// 전체 알림(notifyPushEnabled)과 세부 알림은 같은 요청에 함께 담을 수 없어 훅을 나눠 둡니다.
+export function useUpdateAllSetting() {
   const queryClient = useQueryClient()
   return useMutation({
-    mutationFn: (settings: NotificationSettingsResponse) =>
-      notificationApi.updateSettings(settings),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUERY_KEYS.settings }),
+    mutationFn: notificationApi.updateAllSetting,
+    onSuccess: (settings) => {
+      queryClient.setQueryData(QUERY_KEYS.settings, settings)
+    },
+  })
+}
+
+export function useUpdateSubSettings() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (settings: Omit<NotificationSettingsResponse, 'all'>) =>
+      notificationApi.updateSubSettings(settings),
+    onSuccess: (settings) => {
+      queryClient.setQueryData(QUERY_KEYS.settings, settings)
+    },
   })
 }

--- a/src/features/notification/index.tsx
+++ b/src/features/notification/index.tsx
@@ -30,7 +30,7 @@ interface NotificationProps {
 export default function Notification({ filter, onUnreadCountChange }: NotificationProps) {
   const [sort, setSort] = useState<SortType>('최신순')
   const [sortOpen, setSortOpen] = useState(false)
-  const [readIds, setReadIds] = useState<Set<number>>(new Set())
+  const [readIds, setReadIds] = useState<Set<string>>(new Set())
   const sortRef = useRef<HTMLDivElement>(null)
 
   const { data: serverNotifications = [] } = useNotifications(FILTER_MAP[filter], SORT_MAP[sort])
@@ -57,9 +57,17 @@ export default function Notification({ filter, onUnreadCountChange }: Notificati
     return () => document.removeEventListener('mousedown', handler)
   }, [sortOpen])
 
-  const handleRead = (id: number) => {
+  const handleRead = (id: string) => {
     setReadIds((prev) => new Set([...prev, id]))
-    readOne(id)
+    // 실패하면 서버는 읽지 않음인데 화면만 읽음으로 남으므로 로컬 표시를 되돌립니다.
+    readOne(id, {
+      onError: () =>
+        setReadIds((prev) => {
+          const next = new Set(prev)
+          next.delete(id)
+          return next
+        }),
+    })
   }
 
   return (

--- a/src/features/notification/index.tsx
+++ b/src/features/notification/index.tsx
@@ -2,12 +2,25 @@ import { useEffect, useRef, useState } from 'react'
 import { IoChevronDown } from 'react-icons/io5'
 import NotificationCard from './components/NotificationCard'
 import type { FilterType } from './components/FilterTabs'
-import { useNotifications } from './hooks/useNotifications'
+import { useNotifications, useReadNotification } from './hooks/useNotifications'
 import styles from './Notification.module.css'
 import type { NotificationItem } from './components/NotificationCard'
 
 type SortType = '최신순' | '오래된순' | '읽지 않은 알림 우선'
 const SORT_OPTIONS: SortType[] = ['최신순', '오래된순', '읽지 않은 알림 우선']
+
+const FILTER_MAP: Record<FilterType, string> = {
+  전체: 'ALL',
+  유혹관리: 'TEMPTATION',
+  목표현황: 'GOAL',
+  일반: 'GENERAL',
+}
+
+const SORT_MAP: Record<SortType, string> = {
+  최신순: 'LATEST',
+  오래된순: 'OLDEST',
+  '읽지 않은 알림 우선': 'UNREAD_FIRST',
+}
 
 interface NotificationProps {
   filter: FilterType
@@ -20,7 +33,8 @@ export default function Notification({ filter, onUnreadCountChange }: Notificati
   const [readIds, setReadIds] = useState<Set<number>>(new Set())
   const sortRef = useRef<HTMLDivElement>(null)
 
-  const { data: serverNotifications = [] } = useNotifications()
+  const { data: serverNotifications = [] } = useNotifications(FILTER_MAP[filter], SORT_MAP[sort])
+  const { mutate: readOne } = useReadNotification()
 
   const notifications: NotificationItem[] = serverNotifications.map((n) => ({
     ...n,
@@ -43,20 +57,9 @@ export default function Notification({ filter, onUnreadCountChange }: Notificati
     return () => document.removeEventListener('mousedown', handler)
   }, [sortOpen])
 
-  const filtered =
-    filter === '전체' ? notifications : notifications.filter((n) => n.type === filter)
-
-  const sorted = [...filtered].sort((a, b) => {
-    if (sort === '오래된순') return a.id - b.id
-    if (sort === '읽지 않은 알림 우선') {
-      if (a.isRead === b.isRead) return b.id - a.id
-      return a.isRead ? 1 : -1
-    }
-    return b.id - a.id
-  })
-
   const handleRead = (id: number) => {
     setReadIds((prev) => new Set([...prev, id]))
+    readOne(id)
   }
 
   return (
@@ -86,12 +89,12 @@ export default function Notification({ filter, onUnreadCountChange }: Notificati
         </div>
       </div>
       <ul className={styles.list}>
-        {sorted.map((item) => (
+        {notifications.map((item) => (
           <li key={item.id}>
             <NotificationCard {...item} onRead={handleRead} />
           </li>
         ))}
-        {sorted.length === 0 && <li className={styles.empty}>알림이 없습니다.</li>}
+        {notifications.length === 0 && <li className={styles.empty}>알림이 없습니다.</li>}
       </ul>
     </main>
   )


### PR DESCRIPTION
## 📌 작업 내용

- notificationApi.ts 목업 제거, 실제 API 연결 (목록 조회 / 읽음 처리 / 설정 변경)
- 필터·정렬을 클라이언트가 아닌 서버에서 처리하도록 변경 (type, sort 쿼리 파라미터 전달)
- 알림 카드 클릭 시 PATCH /api/v1/notifications/{id}/read 호출로 읽음 처리
- 알림 설정 전체 토글과 개별 토글을 분리해서 API 호출 (동일 요청에 함께 변경 불가 제약 대응)
- 전체 알림 끄면 개별 토글도 모두 꺼지도록 UI 동기화


## 📷 스크린 샷

-

## ⚠️ 참고 사항

- 알림 설정 조회 GET API가 없어 설정 화면 열 때 항상 전부 켜진 상태로 표시됨 (백엔드 요청 후 수정하고 다시 pr 올리겠습니다!)

## 🔗 관련 이슈

Closes #113 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 실제 백엔드에서 알림 목록과 알림 설정을 불러오고 저장할 수 있습니다.
  * 알림 유형별 필터와 최신순·관련순 정렬을 지원합니다.
  * 개별 알림 읽음 처리 및 전체 읽음 처리를 제공합니다.
  * 알림 유형, 아이콘, 내용, 상대 시간, 읽음 상태가 일관되게 표시됩니다.

* **개선**
  * 알림 설정 변경 사항이 서버와 동기화됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->