### PR TITLE
✨ [Feature] 홈 - 상세 소비 분석 리포트 API 연동

### DIFF
--- a/src/features/home/components/CategoryChart.tsx
+++ b/src/features/home/components/CategoryChart.tsx
@@ -26,7 +26,7 @@ export default function CategoryChart({
     <section className={styles.card}>
       <div className={styles.header}>
         <span className={styles.title}>카테고리별 지출</span>
-        <button className={styles.detailButton} onClick={() => navigate('/report')}>
+        <button className={styles.detailButton} onClick={() => navigate('/consumption-report')}>
           상세 보기 &gt;
         </button>
       </div>

--- a/src/features/mypage/ConsumptionReport.module.css
+++ b/src/features/mypage/ConsumptionReport.module.css
@@ -27,20 +27,3 @@
   line-height: 1;
   color: #898989;
 }
-
-.logo {
-  font-size: 14px;
-  font-weight: 700;
-  font-style: italic;
-}
-
-.backButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: none;
-  background: transparent;
-  cursor: pointer;
-  color: #243130;
-}

--- a/src/features/mypage/ConsumptionReport.tsx
+++ b/src/features/mypage/ConsumptionReport.tsx
@@ -1,5 +1,5 @@
 import Header from '@/components/layout/Header'
-import { IoChevronBack } from 'react-icons/io5'
+import HeaderBackButton from '@/shared/components/HeaderBackButton'
 import { useNavigate } from 'react-router-dom'
 
 import ConsumptionReportForm from './components/ConsumptionReportForm'
@@ -19,17 +19,8 @@ export default function ConsumptionReport() {
   return (
     <>
       <Header
-        left={<span className={styles.logo}>Logo</span>}
-        subLeft={
-          <button
-            type="button"
-            className={styles.backButton}
-            onClick={handleBack}
-            aria-label="뒤로가기"
-          >
-            <IoChevronBack size={20} />
-          </button>
-        }
+        onBellClick={() => navigate('/notification')}
+        subLeft={<HeaderBackButton onClick={handleBack} />}
         subMain={
           <div className={styles.headerContent}>
             <h1 className={styles.pageTitle}>소비 분석 리포트</h1>

--- a/src/features/mypage/api/consumptionReportApi.ts
+++ b/src/features/mypage/api/consumptionReportApi.ts
@@ -1,0 +1,66 @@
+import client from '@/api/client'
+
+export interface ConsumptionCategory {
+  categoryCode: string
+  categoryLabel: string
+  amount: number
+  ratio: number
+}
+
+export interface SavingStatus {
+  totalAttemptCount: number
+  skipped: { amount: number; count: number }
+  consumed: { amount: number; count: number }
+}
+
+export interface GoalAchievement {
+  status: 'NOT_SET' | 'IN_PROGRESS' | 'ACHIEVED'
+  achievementRate: number
+  targetAmount: number | null
+  savedAmount: number
+  remainingAmount: number | null
+}
+
+export interface ConsumptionInsight {
+  type: 'VULNERABLE_TIME' | 'INFLOW_CHANNEL'
+  weekdayLabel: string
+  hour: number | null
+  amount: number | null
+  ratio: number | null
+  channel: string | null
+  count: number | null
+}
+
+export interface CategoryDefenseSummary {
+  categoryCode: string
+  categoryLabel: string
+  skippedAmount: number
+  consumedAmount: number
+  defenseRate: number
+}
+
+export interface ConsumptionReportDetail {
+  reportMonth: string
+  totalConsumption: {
+    totalAmount: number
+    categories: ConsumptionCategory[]
+  }
+  savingStatus: SavingStatus
+  goalAchievement: GoalAchievement
+  insights: {
+    hasEnoughData: boolean
+    insights: ConsumptionInsight[]
+  }
+  categoryDefenseSummary: CategoryDefenseSummary[]
+}
+
+export const consumptionReportApi = {
+  getDetail: async (month?: string): Promise<ConsumptionReportDetail> => {
+    const params = month ? { month } : {}
+    const { data } = await client.get<{ data: ConsumptionReportDetail }>(
+      '/api/v1/reports/consumption/detail',
+      { params },
+    )
+    return data.data
+  },
+}

--- a/src/features/mypage/components/ConsumptionReportForm.module.css
+++ b/src/features/mypage/components/ConsumptionReportForm.module.css
@@ -131,6 +131,18 @@
   font-size: 14px;
 }
 
+.retryButton {
+  margin-top: 8px;
+  padding: 8px 16px;
+  border: 1px solid var(--color-gray-100);
+  border-radius: 8px;
+  background: var(--color-text-white);
+  color: var(--color-text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
 .emptyInsight {
   margin: 0;
   font-size: 13px;

--- a/src/features/mypage/components/ConsumptionReportForm.module.css
+++ b/src/features/mypage/components/ConsumptionReportForm.module.css
@@ -123,3 +123,18 @@
 .monthItem:hover {
   background: #f4f4f4;
 }
+
+.status {
+  text-align: center;
+  padding: 40px 0;
+  color: #9ca3af;
+  font-size: 14px;
+}
+
+.emptyInsight {
+  margin: 0;
+  font-size: 13px;
+  color: #9ca3af;
+  text-align: center;
+  padding: 12px 0;
+}

--- a/src/features/mypage/components/ConsumptionReportForm.tsx
+++ b/src/features/mypage/components/ConsumptionReportForm.tsx
@@ -1,23 +1,51 @@
+import { useState } from 'react'
+import { useConsumptionReport } from '../hooks/useConsumptionReport'
 import DonutChart from './DonutChart'
 import CategoryItem from './CategoryItem'
 import styles from './ConsumptionReportForm.module.css'
 import SavingStatusCard from './SavingStatusCard'
 import SavingCategoryItem from './SavingCategoryItem'
-import { useState } from 'react'
+
+const CATEGORY_COLORS = ['#2F7F82', '#4ECDC4', '#FFE66D', '#FF6B6B', '#A8E6CF', '#DDA0DD']
+
+const CATEGORY_ICONS: Record<string, string> = {
+  FOOD_SNACK: '🍔',
+  FASHION: '👗',
+  HOBBY: '🎮',
+  BEAUTY: '💄',
+  TRAVEL: '✈️',
+  ELECTRONICS: '📱',
+  CULTURE: '🎬',
+  HEALTH: '💊',
+  PET: '🐾',
+  ETC: '📦',
+}
+
+function getRecentMonths(count: number): { label: string; value: string }[] {
+  const result = []
+  const now = new Date()
+  for (let i = 0; i < count; i++) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+    const value = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+    const label = `${d.getFullYear()}년 ${d.getMonth() + 1}월`
+    result.push({ label, value })
+  }
+  return result
+}
 
 export default function ConsumptionReportForm() {
-  const months = ['2026년 5월', '2026년 4월', '2026년 3월']
-
+  const months = getRecentMonths(3)
   const [selectedMonth, setSelectedMonth] = useState(months[0])
   const [isOpen, setIsOpen] = useState(false)
+
+  const { data, loading, error } = useConsumptionReport(selectedMonth.value)
 
   return (
     <div className={styles.wrapper}>
       {/* 월 선택 */}
       <div className={styles.monthWrapper}>
         <button type="button" className={styles.monthButton} onClick={() => setIsOpen(!isOpen)}>
-          <span>{selectedMonth}</span>
-
+          <span>{selectedMonth.label}</span>
           <span className={styles.arrow}>▼</span>
         </button>
 
@@ -25,7 +53,7 @@ export default function ConsumptionReportForm() {
           <div className={styles.monthDropdown}>
             {months.map((month) => (
               <button
-                key={month}
+                key={month.value}
                 type="button"
                 className={styles.monthItem}
                 onClick={() => {
@@ -33,94 +61,106 @@ export default function ConsumptionReportForm() {
                   setIsOpen(false)
                 }}
               >
-                {month}
+                {month.label}
               </button>
             ))}
           </div>
         )}
       </div>
 
-      {/* 총 소비 요약 */}
-      <section className={styles.card}>
-        <h2 className={styles.cardTitle}>총 소비 요약</h2>
+      {loading && <p className={styles.status}>불러오는 중...</p>}
+      {error && <p className={styles.status}>데이터를 불러오지 못했습니다.</p>}
 
-        <div className={styles.summaryContent}>
-          <DonutChart />
-
-          <div className={styles.legend}>
-            <CategoryItem color="#D9D9D9" name="식비" amount="200,000원" percent="33%" />
-
-            <CategoryItem color="#D9D9D9" name="교통" amount="150,000원" percent="25%" />
-
-            <CategoryItem color="#D9D9D9" name="여가" amount="120,000원" percent="20%" />
-
-            <CategoryItem color="#D9D9D9" name="쇼핑" amount="80,000원" percent="13%" />
-
-            <CategoryItem color="#D9D9D9" name="기타" amount="50,000원" percent="9%" />
-          </div>
-        </div>
-      </section>
-
-      {/* 통합 절약 현황 */}
-      <section className={styles.card}>
-        <SavingStatusCard />
-      </section>
-
-      {/* 나의 충동 소비 패턴 */}
-      <section className={styles.card}>
-        <h2 className={styles.cardTitle}>나의 충동 소비 패턴</h2>
-
-        <div className={styles.patternBox}>
-          <div className={styles.patternCard}>
-            <span className={styles.patternIcon}>⏰</span>
-
-            <div className={styles.patternContent}>
-              <p className={styles.patternTitle}>가장 취약한 시간대는 금요일 밤 11시</p>
-
-              <p className={styles.patternDescription}>
-                전체 지출의 40%가 금요일 심야에 발생했습니다. 이 시간대에는 쇼핑 앱 접속을
-                주의하세요.
-              </p>
+      {data && (
+        <>
+          {/* 총 소비 요약 */}
+          <section className={styles.card}>
+            <h2 className={styles.cardTitle}>총 소비 요약</h2>
+            <div className={styles.summaryContent}>
+              <DonutChart totalAmount={data.totalConsumption.totalAmount} />
+              <div className={styles.legend}>
+                {data.totalConsumption.categories.map((cat, i) => (
+                  <CategoryItem
+                    key={cat.categoryCode}
+                    color={CATEGORY_COLORS[i % CATEGORY_COLORS.length]}
+                    name={cat.categoryLabel}
+                    amount={`${cat.amount.toLocaleString('ko-KR')}원`}
+                    percent={`${cat.ratio}%`}
+                  />
+                ))}
+              </div>
             </div>
-          </div>
+          </section>
 
-          <div className={styles.patternCard}>
-            <span className={styles.patternIcon}>🔗</span>
+          {/* 통합 절약 현황 */}
+          <section className={styles.card}>
+            <SavingStatusCard
+              savingStatus={data.savingStatus}
+              goalAchievement={data.goalAchievement}
+            />
+          </section>
 
-            <div className={styles.patternContent}>
-              <p className={styles.patternTitle}>주요 충동 유입 경로는 인스타그램 URL</p>
-
-              <p className={styles.patternDescription}>
-                기록된 소비 시도 중 SNS 링크를 통한 유입이 압도적으로 많았습니다. 광고에 즉각적으로
-                반응하는 패턴을 보입니다.
+          {/* 나의 충동 소비 패턴 */}
+          <section className={styles.card}>
+            <h2 className={styles.cardTitle}>나의 충동 소비 패턴</h2>
+            {data.insights.hasEnoughData ? (
+              <div className={styles.patternBox}>
+                {data.insights.insights.map((insight, i) => (
+                  <div key={i} className={styles.patternCard}>
+                    <span className={styles.patternIcon}>
+                      {insight.type === 'VULNERABLE_TIME' ? '⏰' : '🔗'}
+                    </span>
+                    <div className={styles.patternContent}>
+                      {insight.type === 'VULNERABLE_TIME' && (
+                        <>
+                          <p className={styles.patternTitle}>
+                            가장 취약한 시간대는 {insight.weekdayLabel}요일{' '}
+                            {insight.hour != null ? `${insight.hour}시` : ''}
+                          </p>
+                          <p className={styles.patternDescription}>
+                            전체 지출의 {insight.ratio}%가 이 시간대에 발생했습니다.
+                          </p>
+                        </>
+                      )}
+                      {insight.type === 'INFLOW_CHANNEL' && (
+                        <>
+                          <p className={styles.patternTitle}>
+                            주요 충동 유입 경로는 {insight.channel}
+                          </p>
+                          <p className={styles.patternDescription}>
+                            해당 경로를 통한 소비 시도가 {insight.count}건 기록되었습니다.
+                          </p>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className={styles.emptyInsight}>
+                소비 기록이 3건 이상 쌓이면 패턴을 분석해드려요.
               </p>
-            </div>
-          </div>
-        </div>
-      </section>
+            )}
+          </section>
 
-      {/* 카테고리별 소비 및 절약 요약 */}
-      <section className={styles.card}>
-        <h2 className={styles.cardTitle}>카테고리별 소비 및 절약 요약</h2>
-
-        <SavingCategoryItem
-          icon="🍔"
-          name="배달 / 외식"
-          defense={85}
-          saved="102,000"
-          spent="18,000"
-        />
-
-        <SavingCategoryItem
-          icon="👗"
-          name="패션 / 잡화"
-          defense={50}
-          saved="80,000"
-          spent="80,000"
-        />
-
-        <SavingCategoryItem icon="🎮" name="취미 / 게임" defense={100} saved="163,000" spent="0" />
-      </section>
+          {/* 카테고리별 소비 및 절약 요약 */}
+          {data.categoryDefenseSummary.length > 0 && (
+            <section className={styles.card}>
+              <h2 className={styles.cardTitle}>카테고리별 소비 및 절약 요약</h2>
+              {data.categoryDefenseSummary.map((cat) => (
+                <SavingCategoryItem
+                  key={cat.categoryCode}
+                  icon={CATEGORY_ICONS[cat.categoryCode] ?? '📦'}
+                  name={cat.categoryLabel}
+                  defense={cat.defenseRate}
+                  saved={cat.skippedAmount.toLocaleString('ko-KR')}
+                  spent={cat.consumedAmount.toLocaleString('ko-KR')}
+                />
+              ))}
+            </section>
+          )}
+        </>
+      )}
     </div>
   )
 }

--- a/src/features/mypage/components/ConsumptionReportForm.tsx
+++ b/src/features/mypage/components/ConsumptionReportForm.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { formatKRW } from '@/shared/utils/currency'
 import { useConsumptionReport } from '../hooks/useConsumptionReport'
 import DonutChart from './DonutChart'
 import CategoryItem from './CategoryItem'
@@ -6,44 +7,84 @@ import styles from './ConsumptionReportForm.module.css'
 import SavingStatusCard from './SavingStatusCard'
 import SavingCategoryItem from './SavingCategoryItem'
 
-const CATEGORY_COLORS = ['#2F7F82', '#4ECDC4', '#FFE66D', '#FF6B6B', '#A8E6CF', '#DDA0DD']
+// 카테고리가 9종이라 색도 9개를 둡니다.
+// 개수가 모자라면 서로 다른 카테고리에 같은 색이 배정돼 차트/범례에서 구분이 안 됩니다.
+const CATEGORY_COLORS = [
+  '#2F7F82',
+  '#4ECDC4',
+  '#FFE66D',
+  '#FF6B6B',
+  '#A8E6CF',
+  '#DDA0DD',
+  '#F4A261',
+  '#8AB6F9',
+  '#B0BEC5',
+]
 
+// 백엔드 카테고리 코드 9종 기준 (소비기록 API와 동일한 코드 체계)
 const CATEGORY_ICONS: Record<string, string> = {
-  FOOD_SNACK: '🍔',
   FASHION: '👗',
-  HOBBY: '🎮',
   BEAUTY: '💄',
-  TRAVEL: '✈️',
+  FOOD_SNACK: '🍔',
+  CAFE_DESSERT: '☕',
+  HOBBY_GOODS: '🎮',
   ELECTRONICS: '📱',
-  CULTURE: '🎬',
-  HEALTH: '💊',
-  PET: '🐾',
+  HEALTH_FITNESS: '💪',
+  TRAVEL: '✈️',
   ETC: '📦',
 }
 
+// 서버는 KST 기준으로 "미래 월"을 판단해 400을 반환하므로,
+// 기기 시간대와 무관하게 서울 기준 연/월에서 목록을 만듭니다.
+const KST_YEAR_MONTH = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Seoul',
+  year: 'numeric',
+  month: '2-digit',
+})
+
 function getRecentMonths(count: number): { label: string; value: string }[] {
-  const result = []
-  const now = new Date()
-  for (let i = 0; i < count; i++) {
-    const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
-    const value = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
-    const label = `${d.getFullYear()}년 ${d.getMonth() + 1}월`
-    result.push({ label, value })
-  }
-  return result
+  const parts = KST_YEAR_MONTH.formatToParts(new Date())
+  const get = (type: string) => Number(parts.find((part) => part.type === type)?.value)
+  const currentYear = get('year')
+  const currentMonth = get('month')
+
+  return Array.from({ length: count }, (_, i) => {
+    // 월을 0-based로 바꿔 뺀 뒤 다시 1-based로 되돌려 연도 넘김을 자연스럽게 처리합니다.
+    const date = new Date(Date.UTC(currentYear, currentMonth - 1 - i, 1))
+    const year = date.getUTCFullYear()
+    const month = date.getUTCMonth() + 1
+
+    return {
+      label: `${year}년 ${month}월`,
+      value: `${year}-${String(month).padStart(2, '0')}`,
+    }
+  })
 }
 
 export default function ConsumptionReportForm() {
   const months = getRecentMonths(3)
   const [selectedMonth, setSelectedMonth] = useState(months[0])
   const [isOpen, setIsOpen] = useState(false)
+  const monthRef = useRef<HTMLDivElement>(null)
 
-  const { data, loading, error } = useConsumptionReport(selectedMonth.value)
+  // 드롭다운 바깥을 누르면 닫습니다. (알림 화면 정렬 드롭다운과 동일한 방식)
+  useEffect(() => {
+    if (!isOpen) return
+    const handleClickOutside = (event: MouseEvent) => {
+      if (monthRef.current && !monthRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen])
+
+  const { data, isLoading, isError, refetch } = useConsumptionReport(selectedMonth.value)
 
   return (
     <div className={styles.wrapper}>
       {/* 월 선택 */}
-      <div className={styles.monthWrapper}>
+      <div className={styles.monthWrapper} ref={monthRef}>
         <button type="button" className={styles.monthButton} onClick={() => setIsOpen(!isOpen)}>
           <span>{selectedMonth.label}</span>
           <span className={styles.arrow}>▼</span>
@@ -68,8 +109,15 @@ export default function ConsumptionReportForm() {
         )}
       </div>
 
-      {loading && <p className={styles.status}>불러오는 중...</p>}
-      {error && <p className={styles.status}>데이터를 불러오지 못했습니다.</p>}
+      {isLoading && <p className={styles.status}>불러오는 중...</p>}
+      {isError && (
+        <div className={styles.status}>
+          <p>데이터를 불러오지 못했습니다.</p>
+          <button type="button" className={styles.retryButton} onClick={() => refetch()}>
+            다시 시도
+          </button>
+        </div>
+      )}
 
       {data && (
         <>
@@ -77,14 +125,21 @@ export default function ConsumptionReportForm() {
           <section className={styles.card}>
             <h2 className={styles.cardTitle}>총 소비 요약</h2>
             <div className={styles.summaryContent}>
-              <DonutChart totalAmount={data.totalConsumption.totalAmount} />
+              {/* 차트와 범례가 같은 색·같은 비율을 쓰도록 동일한 배열에서 파생시킵니다. */}
+              <DonutChart
+                totalAmount={data.totalConsumption.totalAmount}
+                segments={data.totalConsumption.categories.map((cat, i) => ({
+                  color: CATEGORY_COLORS[i % CATEGORY_COLORS.length],
+                  ratio: cat.ratio,
+                }))}
+              />
               <div className={styles.legend}>
                 {data.totalConsumption.categories.map((cat, i) => (
                   <CategoryItem
                     key={cat.categoryCode}
                     color={CATEGORY_COLORS[i % CATEGORY_COLORS.length]}
                     name={cat.categoryLabel}
-                    amount={`${cat.amount.toLocaleString('ko-KR')}원`}
+                    amount={formatKRW(cat.amount)}
                     percent={`${cat.ratio}%`}
                   />
                 ))}
@@ -117,9 +172,11 @@ export default function ConsumptionReportForm() {
                             가장 취약한 시간대는 {insight.weekdayLabel}요일{' '}
                             {insight.hour != null ? `${insight.hour}시` : ''}
                           </p>
-                          <p className={styles.patternDescription}>
-                            전체 지출의 {insight.ratio}%가 이 시간대에 발생했습니다.
-                          </p>
+                          {insight.ratio != null && (
+                            <p className={styles.patternDescription}>
+                              전체 지출의 {insight.ratio}%가 이 시간대에 발생했습니다.
+                            </p>
+                          )}
                         </>
                       )}
                       {insight.type === 'INFLOW_CHANNEL' && (
@@ -127,9 +184,11 @@ export default function ConsumptionReportForm() {
                           <p className={styles.patternTitle}>
                             주요 충동 유입 경로는 {insight.channel}
                           </p>
-                          <p className={styles.patternDescription}>
-                            해당 경로를 통한 소비 시도가 {insight.count}건 기록되었습니다.
-                          </p>
+                          {insight.count != null && (
+                            <p className={styles.patternDescription}>
+                              해당 경로를 통한 소비 시도가 {insight.count}건 기록되었습니다.
+                            </p>
+                          )}
                         </>
                       )}
                     </div>

--- a/src/features/mypage/components/DonutChart.tsx
+++ b/src/features/mypage/components/DonutChart.tsx
@@ -1,17 +1,47 @@
+import { formatKRW } from '@/shared/utils/currency'
 import styles from './DonutChart.module.css'
+
+export interface DonutSegment {
+  color: string
+  ratio: number
+}
 
 interface DonutChartProps {
   totalAmount: number
+  segments?: DonutSegment[]
 }
 
-export default function DonutChart({ totalAmount }: DonutChartProps) {
-  const formatted = totalAmount.toLocaleString('ko-KR') + '원'
+// 카테고리 비율을 conic-gradient 구간으로 변환합니다.
+// 합이 100에 못 미치면 남은 부분은 회색으로 채웁니다.
+function buildGradient(segments: DonutSegment[]): string {
+  const stops: string[] = []
+  let cursor = 0
+
+  for (const { color, ratio } of segments) {
+    if (ratio <= 0) continue
+    const next = Math.min(cursor + ratio, 100)
+    stops.push(`${color} ${cursor}% ${next}%`)
+    cursor = next
+  }
+
+  if (cursor < 100) {
+    stops.push(`var(--color-gray-100, #e5e7eb) ${cursor}% 100%`)
+  }
+
+  return `conic-gradient(${stops.join(', ')})`
+}
+
+export default function DonutChart({ totalAmount, segments }: DonutChartProps) {
+  const hasSegments = segments !== undefined && segments.length > 0
 
   return (
-    <div className={styles.chart}>
+    <div
+      className={styles.chart}
+      style={hasSegments ? { background: buildGradient(segments) } : undefined}
+    >
       <div className={styles.innerCircle}>
         <div className={styles.text}>
-          <p className={styles.amount}>{formatted}</p>
+          <p className={styles.amount}>{formatKRW(totalAmount)}</p>
         </div>
       </div>
     </div>

--- a/src/features/mypage/components/DonutChart.tsx
+++ b/src/features/mypage/components/DonutChart.tsx
@@ -1,11 +1,17 @@
 import styles from './DonutChart.module.css'
 
-export default function DonutChart() {
+interface DonutChartProps {
+  totalAmount: number
+}
+
+export default function DonutChart({ totalAmount }: DonutChartProps) {
+  const formatted = totalAmount.toLocaleString('ko-KR') + '원'
+
   return (
     <div className={styles.chart}>
       <div className={styles.innerCircle}>
         <div className={styles.text}>
-          <p className={styles.amount}>750,000원</p>
+          <p className={styles.amount}>{formatted}</p>
         </div>
       </div>
     </div>

--- a/src/features/mypage/components/SavingStatusCard.tsx
+++ b/src/features/mypage/components/SavingStatusCard.tsx
@@ -1,45 +1,59 @@
+import type { SavingStatus, GoalAchievement } from '../api/consumptionReportApi'
 import styles from './SavingStatusCard.module.css'
 
-export default function SavingStatusCard() {
+interface SavingStatusCardProps {
+  savingStatus: SavingStatus
+  goalAchievement: GoalAchievement
+}
+
+export default function SavingStatusCard({ savingStatus, goalAchievement }: SavingStatusCardProps) {
+  const { totalAttemptCount, skipped, consumed } = savingStatus
+  const { status, achievementRate, savedAmount, remainingAmount } = goalAchievement
+
+  const hasGoal = status !== 'NOT_SET'
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.header}>
         <h2 className={styles.title}>통합 절약 현황</h2>
-
-        <span className={styles.count}>총 24번의 소비 시도 중</span>
+        <span className={styles.count}>총 {totalAttemptCount}번의 소비 시도 중</span>
       </div>
 
       <div className={styles.summary}>
         <div className={styles.leftCard}>
           <p className={styles.label}>참은 소비 (절약액)</p>
-
-          <h3 className={styles.money}>₩ 345,000</h3>
-
-          <span className={styles.desc}>방어 성공 18회</span>
+          <h3 className={styles.money}>₩ {skipped.amount.toLocaleString('ko-KR')}</h3>
+          <span className={styles.desc}>방어 성공 {skipped.count}회</span>
         </div>
 
         <div className={styles.rightInfo}>
           <p className={styles.label}>실제 지출 금액</p>
-
-          <h3 className={styles.money}>₩ 120,000</h3>
-
-          <span className={styles.desc}>지출 결제 6회</span>
+          <h3 className={styles.money}>₩ {consumed.amount.toLocaleString('ko-KR')}</h3>
+          <span className={styles.desc}>지출 결제 {consumed.count}회</span>
         </div>
       </div>
 
-      <hr className={styles.divider} />
-
-      <div className={styles.goalHeader}>
-        <span className={styles.goalTitle}>🎯 절약 목표</span>
-
-        <span className={styles.goalPercent}>69% 달성</span>
-      </div>
-
-      <div className={styles.progress}>
-        <div className={styles.progressFill} />
-      </div>
-
-      <p className={styles.remain}>155,000원 남았어요!</p>
+      {hasGoal && (
+        <>
+          <hr className={styles.divider} />
+          <div className={styles.goalHeader}>
+            <span className={styles.goalTitle}>🎯 절약 목표</span>
+            <span className={styles.goalPercent}>{achievementRate}% 달성</span>
+          </div>
+          <div className={styles.progress}>
+            <div
+              className={styles.progressFill}
+              style={{ width: `${Math.min(achievementRate, 100)}%` }}
+            />
+          </div>
+          {remainingAmount != null && remainingAmount > 0 && (
+            <p className={styles.remain}>{remainingAmount.toLocaleString('ko-KR')}원 남았어요!</p>
+          )}
+          {(status === 'ACHIEVED' || remainingAmount === 0) && (
+            <p className={styles.remain}>목표 달성! 🎉</p>
+          )}
+        </>
+      )}
     </div>
   )
 }

--- a/src/features/mypage/components/SavingStatusCard.tsx
+++ b/src/features/mypage/components/SavingStatusCard.tsx
@@ -8,7 +8,7 @@ interface SavingStatusCardProps {
 
 export default function SavingStatusCard({ savingStatus, goalAchievement }: SavingStatusCardProps) {
   const { totalAttemptCount, skipped, consumed } = savingStatus
-  const { status, achievementRate, savedAmount, remainingAmount } = goalAchievement
+  const { status, achievementRate, remainingAmount } = goalAchievement
 
   const hasGoal = status !== 'NOT_SET'
 

--- a/src/features/mypage/hooks/useConsumptionReport.ts
+++ b/src/features/mypage/hooks/useConsumptionReport.ts
@@ -1,0 +1,20 @@
+import { useState, useEffect } from 'react'
+import { consumptionReportApi, type ConsumptionReportDetail } from '../api/consumptionReportApi'
+
+export function useConsumptionReport(month?: string) {
+  const [data, setData] = useState<ConsumptionReportDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<Error | null>(null)
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    consumptionReportApi
+      .getDetail(month)
+      .then(setData)
+      .catch((e: unknown) => setError(e instanceof Error ? e : new Error('조회 실패')))
+      .finally(() => setLoading(false))
+  }, [month])
+
+  return { data, loading, error }
+}

--- a/src/features/mypage/hooks/useConsumptionReport.ts
+++ b/src/features/mypage/hooks/useConsumptionReport.ts
@@ -1,35 +1,14 @@
-import { useEffect, useReducer } from 'react'
-import { consumptionReportApi, type ConsumptionReportDetail } from '../api/consumptionReportApi'
+import { useQuery } from '@tanstack/react-query'
+import { consumptionReportApi } from '../api/consumptionReportApi'
 
-type State = {
-  data: ConsumptionReportDetail | null
-  loading: boolean
-  error: Error | null
-}
-
-type Action =
-  | { type: 'loading' }
-  | { type: 'success'; data: ConsumptionReportDetail }
-  | { type: 'error'; error: Error }
-
-function reducer(_: State, action: Action): State {
-  if (action.type === 'loading') return { data: null, loading: true, error: null }
-  if (action.type === 'success') return { data: action.data, loading: false, error: null }
-  return { data: null, loading: false, error: action.error }
+const QUERY_KEYS = {
+  detail: (month?: string) => ['consumption-report', 'detail', month ?? 'current'] as const,
 }
 
 export function useConsumptionReport(month?: string) {
-  const [state, dispatch] = useReducer(reducer, { data: null, loading: true, error: null })
-
-  useEffect(() => {
-    dispatch({ type: 'loading' })
-    consumptionReportApi
-      .getDetail(month)
-      .then((data) => dispatch({ type: 'success', data }))
-      .catch((e: unknown) =>
-        dispatch({ type: 'error', error: e instanceof Error ? e : new Error('조회 실패') }),
-      )
-  }, [month])
-
-  return state
+  return useQuery({
+    queryKey: QUERY_KEYS.detail(month),
+    queryFn: () => consumptionReportApi.getDetail(month),
+    staleTime: 1000 * 60 * 5,
+  })
 }

--- a/src/features/mypage/hooks/useConsumptionReport.ts
+++ b/src/features/mypage/hooks/useConsumptionReport.ts
@@ -1,20 +1,35 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useReducer } from 'react'
 import { consumptionReportApi, type ConsumptionReportDetail } from '../api/consumptionReportApi'
 
+type State = {
+  data: ConsumptionReportDetail | null
+  loading: boolean
+  error: Error | null
+}
+
+type Action =
+  | { type: 'loading' }
+  | { type: 'success'; data: ConsumptionReportDetail }
+  | { type: 'error'; error: Error }
+
+function reducer(_: State, action: Action): State {
+  if (action.type === 'loading') return { data: null, loading: true, error: null }
+  if (action.type === 'success') return { data: action.data, loading: false, error: null }
+  return { data: null, loading: false, error: action.error }
+}
+
 export function useConsumptionReport(month?: string) {
-  const [data, setData] = useState<ConsumptionReportDetail | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<Error | null>(null)
+  const [state, dispatch] = useReducer(reducer, { data: null, loading: true, error: null })
 
   useEffect(() => {
-    setLoading(true)
-    setError(null)
+    dispatch({ type: 'loading' })
     consumptionReportApi
       .getDetail(month)
-      .then(setData)
-      .catch((e: unknown) => setError(e instanceof Error ? e : new Error('조회 실패')))
-      .finally(() => setLoading(false))
+      .then((data) => dispatch({ type: 'success', data }))
+      .catch((e: unknown) =>
+        dispatch({ type: 'error', error: e instanceof Error ? e : new Error('조회 실패') }),
+      )
   }, [month])
 
-  return { data, loading, error }
+  return state
 }


### PR DESCRIPTION
## 📌 작업 내용

- GET /api/v1/reports/consumption/detail 연결 (consumptionReportApi, useConsumptionReport)
- ConsumptionReportForm: 최근 3개월 탭 + 실제 API 데이터 렌더링
- DonutChart: totalAmount prop 추가
- SavingStatusCard: savingStatus/goalAchievement prop 추가
- 홈 CategoryChart 상세보기 → /consumption-report 라우트 수정

## 📷 스크린 샷

-

## ⚠️ 참고 사항

-

## 🔗 관련 이슈

Closes #115 
