### PR TITLE
✨ [Feature] 알림 - 삭제 API 연동

### DIFF
--- a/src/features/notification/api/notificationApi.ts
+++ b/src/features/notification/api/notificationApi.ts
@@ -110,6 +110,10 @@ export const notificationApi = {
     await client.patch('/api/v1/notifications/read-all')
   },
 
+  deleteOne: async (id: string): Promise<void> => {
+    await client.delete(`/api/v1/notifications/${id}`)
+  },
+
   getSettings: async (): Promise<NotificationSettingsResponse> => {
     const { data } = await client.get<{ data: NotificationSettingsResult }>(
       NOTIFICATION_SETTINGS_URL,

--- a/src/features/notification/components/NotificationCard.tsx
+++ b/src/features/notification/components/NotificationCard.tsx
@@ -40,6 +40,7 @@ const ICON_CONFIG: Record<
 
 interface Props extends NotificationItem {
   onRead: (id: string) => void
+  onDelete?: (id: string) => void
 }
 
 export default function NotificationCard({
@@ -50,18 +51,20 @@ export default function NotificationCard({
   iconVariant,
   isRead,
   onRead,
+  onDelete,
 }: Props) {
   const { bg, color, border, Icon } = ICON_CONFIG[iconVariant]
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
   const btnRef = useRef<HTMLButtonElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!menuOpen) return
     const handleClickOutside = (e: MouseEvent) => {
-      if (btnRef.current && !btnRef.current.contains(e.target as Node)) {
-        setMenuOpen(false)
-      }
+      const inBtn = btnRef.current?.contains(e.target as Node)
+      const inDropdown = dropdownRef.current?.contains(e.target as Node)
+      if (!inBtn && !inDropdown) setMenuOpen(false)
     }
     document.addEventListener('mousedown', handleClickOutside)
     return () => document.removeEventListener('mousedown', handleClickOutside)
@@ -112,12 +115,17 @@ export default function NotificationCard({
 
       {menuOpen &&
         createPortal(
-          <div className={styles.dropdown} style={{ top: menuPos.top, right: menuPos.right }}>
+          <div
+            ref={dropdownRef}
+            className={styles.dropdown}
+            style={{ top: menuPos.top, right: menuPos.right }}
+          >
             <button
               className={styles.dropdownItem}
               onClick={(e) => {
                 e.stopPropagation()
                 setMenuOpen(false)
+                onDelete?.(id)
               }}
             >
               <IoTrashOutline size={16} />

--- a/src/features/notification/hooks/useNotifications.ts
+++ b/src/features/notification/hooks/useNotifications.ts
@@ -38,8 +38,9 @@ export function useDeleteNotification() {
       const snapshots = queryClient.getQueriesData<NotificationItem[]>({
         queryKey: QUERY_KEYS.lists,
       })
-      queryClient.setQueriesData<NotificationItem[]>({ queryKey: QUERY_KEYS.lists }, (old) =>
-        old?.filter((n) => n.id !== id) ?? [],
+      queryClient.setQueriesData<NotificationItem[]>(
+        { queryKey: QUERY_KEYS.lists },
+        (old) => old?.filter((n) => n.id !== id) ?? [],
       )
       return { snapshots }
     },

--- a/src/features/notification/hooks/useNotifications.ts
+++ b/src/features/notification/hooks/useNotifications.ts
@@ -2,6 +2,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { isAxiosError } from 'axios'
 import { notificationApi } from '../api/notificationApi'
 import type { NotificationSettingsResponse } from '../api/notificationApi'
+import type { NotificationItem } from '../components/NotificationCard'
 
 const QUERY_KEYS = {
   // 목록은 필터/정렬별로 나뉘므로 prefix 단위 무효화를 위해 'notifications'를 공유합니다.
@@ -25,6 +26,27 @@ export function useReadNotification() {
     mutationFn: notificationApi.readOne,
     // 읽음 상태는 필터/정렬별 목록 캐시에 모두 걸쳐 있어 목록 prefix 단위로 무효화합니다.
     onSuccess: () => queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lists }),
+  })
+}
+
+export function useDeleteNotification() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: notificationApi.deleteOne,
+    onMutate: async (id) => {
+      await queryClient.cancelQueries({ queryKey: QUERY_KEYS.lists })
+      const snapshots = queryClient.getQueriesData<NotificationItem[]>({
+        queryKey: QUERY_KEYS.lists,
+      })
+      queryClient.setQueriesData<NotificationItem[]>({ queryKey: QUERY_KEYS.lists }, (old) =>
+        old?.filter((n) => n.id !== id) ?? [],
+      )
+      return { snapshots }
+    },
+    onError: (_, __, context) => {
+      context?.snapshots.forEach(([key, data]) => queryClient.setQueryData(key, data))
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: QUERY_KEYS.lists }),
   })
 }
 

--- a/src/features/notification/index.tsx
+++ b/src/features/notification/index.tsx
@@ -2,7 +2,11 @@ import { useEffect, useRef, useState } from 'react'
 import { IoChevronDown } from 'react-icons/io5'
 import NotificationCard from './components/NotificationCard'
 import type { FilterType } from './components/FilterTabs'
-import { useNotifications, useReadNotification, useDeleteNotification } from './hooks/useNotifications'
+import {
+  useNotifications,
+  useReadNotification,
+  useDeleteNotification,
+} from './hooks/useNotifications'
 import styles from './Notification.module.css'
 import type { NotificationItem } from './components/NotificationCard'
 

--- a/src/features/notification/index.tsx
+++ b/src/features/notification/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { IoChevronDown } from 'react-icons/io5'
 import NotificationCard from './components/NotificationCard'
 import type { FilterType } from './components/FilterTabs'
-import { useNotifications, useReadNotification } from './hooks/useNotifications'
+import { useNotifications, useReadNotification, useDeleteNotification } from './hooks/useNotifications'
 import styles from './Notification.module.css'
 import type { NotificationItem } from './components/NotificationCard'
 
@@ -35,6 +35,7 @@ export default function Notification({ filter, onUnreadCountChange }: Notificati
 
   const { data: serverNotifications = [] } = useNotifications(FILTER_MAP[filter], SORT_MAP[sort])
   const { mutate: readOne } = useReadNotification()
+  const { mutate: deleteNotification } = useDeleteNotification()
 
   const notifications: NotificationItem[] = serverNotifications.map((n) => ({
     ...n,
@@ -99,7 +100,7 @@ export default function Notification({ filter, onUnreadCountChange }: Notificati
       <ul className={styles.list}>
         {notifications.map((item) => (
           <li key={item.id}>
-            <NotificationCard {...item} onRead={handleRead} />
+            <NotificationCard {...item} onRead={handleRead} onDelete={deleteNotification} />
           </li>
         ))}
         {notifications.length === 0 && <li className={styles.empty}>알림이 없습니다.</li>}


### PR DESCRIPTION
## 📌 작업 내용

- notificationApi.ts 삭제 API 연결 및 삭제 버튼 UI 동작 수정
- deleteOne mock 제거, 실제 DELETE /api/v1/notifications/{id} 호출로 교체
- NotificationCard에 onDelete prop 추가, 삭제하기 버튼 클릭 시 호출
- useDeleteNotification에 낙관적 업데이트 적용 — 삭제 즉시 캐시에서 제거, API 실패 시 롤백 없이 유지 (목록 API 연결 전 임시)
- createPortal 드롭다운의 mousedown 바깥 클릭 감지 버그 수정 — 드롭다운 내부 클릭이 포털 닫힘으로 처리돼 click 이벤트가 발화되지 않던 문제 해결 (dropdownRef 추가)

## 📷 스크린 샷

-

## ⚠️ 참고 사항

-

## 🔗 관련 이슈

Closes #127 
