### PR TITLE
✨ [Feature] 홈 요약 API 연동

### DIFF
--- a/src/features/home/api/homeApi.ts
+++ b/src/features/home/api/homeApi.ts
@@ -1,72 +1,81 @@
-// import client from '@/api/client'
-import type { HomeData, CategoryData } from '../types'
+import client from '@/api/client'
+import type { CategoryData, GoalAchievementStatus, HomeData, RemainingBudgetStatus } from '../types'
 
 const BAR_COLORS = ['#286A6D', '#C7E3E3', '#E5F2F1', '#2F7F82', '#286A6D']
 
-// ─── Mock 데이터 (API 연결 후 제거) ────────────────────────────────────────
-interface SpendingRecord {
-  category: string
-  amount: number
-  type: 'bought' | 'resisted'
+interface HomeSummaryData {
+  goalAchievement: {
+    status: GoalAchievementStatus
+    rate: number
+    remainingAmount: number | null
+    message: string
+  }
+  consumptionChart: {
+    hasData: boolean
+    categories: {
+      categoryCode: string
+      categoryLabel: string
+      amount: number
+      ratio: number
+    }[]
+    others: { amount: number; ratio: number } | null
+    summaryText: string
+  }
+  thisMonthSpending: {
+    amount: number
+    comparisonRate: number | null
+    comparisonMessage: string | null
+  }
+  remainingBudget: {
+    status: RemainingBudgetStatus
+    amount: number | null
+    message: string
+  }
 }
 
-const mockRecords: SpendingRecord[] = [
-  { category: '음식', amount: 150000, type: 'bought' },
-  { category: '취미/굿즈', amount: 80000, type: 'bought' },
-  { category: '패션', amount: 120000, type: 'bought' },
-  { category: '여행', amount: 60000, type: 'bought' },
-  { category: '뷰티', amount: 30000, type: 'bought' },
-  { category: '음식', amount: 30000, type: 'resisted' },
-  { category: '전자기기', amount: 200000, type: 'resisted' },
-  { category: '패션', amount: 120000, type: 'resisted' },
-]
-
-function buildHomeData(): HomeData {
-  const bought = mockRecords.filter((r) => r.type === 'bought')
-  const resisted = mockRecords.filter((r) => r.type === 'resisted')
-
-  const categoryMap = new Map<string, number>()
-  for (const r of bought) {
-    categoryMap.set(r.category, (categoryMap.get(r.category) ?? 0) + r.amount)
-  }
-
-  const sorted = [...categoryMap.entries()].sort((a, b) => b[1] - a[1])
-  const top4 = sorted.slice(0, 4)
-  const rest = sorted.slice(4)
-  const otherAmount = rest.reduce((sum, [, amount]) => sum + amount, 0)
-
+function mapHomeSummary(data: HomeSummaryData): HomeData {
   const categories: CategoryData[] = [
-    ...top4.map(([label, amount], i) => ({
-      label,
-      amount,
-      color: BAR_COLORS[i],
+    ...data.consumptionChart.categories.map((c, i) => ({
+      categoryCode: c.categoryCode,
+      label: c.categoryLabel,
+      amount: c.amount,
+      ratio: c.ratio,
+      color: BAR_COLORS[i] ?? BAR_COLORS[BAR_COLORS.length - 1],
       isOther: false,
     })),
-    ...(otherAmount > 0
-      ? [{ label: '그 외', amount: otherAmount, color: BAR_COLORS[4], isOther: true }]
+    ...(data.consumptionChart.others
+      ? [
+          {
+            categoryCode: 'ETC',
+            label: '그 외',
+            amount: data.consumptionChart.others.amount,
+            ratio: data.consumptionChart.others.ratio,
+            color: BAR_COLORS[BAR_COLORS.length - 1],
+            isOther: true,
+          },
+        ]
       : []),
   ]
 
-  const monthlySpending = bought.reduce((sum, r) => sum + r.amount, 0)
-  const goalCurrent = resisted.reduce((sum, r) => sum + r.amount, 0)
-
   return {
-    monthlySpending,
-    lastMonthSpending: 320000,
-    budget: 500000,
-    goalAmount: 500000,
-    goalCurrent,
+    goalStatus: data.goalAchievement.status,
+    achievementRate: data.goalAchievement.rate,
+    achievementRemainingAmount: data.goalAchievement.remainingAmount,
+    monthlySpending: data.thisMonthSpending.amount,
+    comparisonRate: data.thisMonthSpending.comparisonRate,
+    comparisonMessage: data.thisMonthSpending.comparisonMessage,
+    budgetStatus: data.remainingBudget.status,
+    remainingBudget: data.remainingBudget.amount,
+    budgetMessage: data.remainingBudget.message,
     categories,
-    hasRecords: bought.length > 0,
+    categorySummaryText: data.consumptionChart.summaryText,
+    hasRecords: data.consumptionChart.hasData,
   }
 }
-// ──────────────────────────────────────────────────────────────────────────
 
 export const homeApi = {
   getHomeData: async (): Promise<HomeData> => {
-    // TODO: API 연결 시 아래 두 줄로 교체하고 mock 제거
-    // const { data } = await client.get<HomeData>('/home')
-    // return data
-    return buildHomeData()
+    const { data } = await client.get<{ data: HomeSummaryData }>('/api/v1/home/summary')
+    return mapHomeSummary(data.data)
   },
 }

--- a/src/features/home/components/CategoryChart.tsx
+++ b/src/features/home/components/CategoryChart.tsx
@@ -6,21 +6,14 @@ import styles from './CategoryChart.module.css'
 interface CategoryChartProps {
   categories: CategoryData[]
   hasRecords: boolean
-  topCategoryLabel: string
+  summaryText: string
 }
 
 const MAX_BAR_HEIGHT = 62
 
-export default function CategoryChart({
-  categories,
-  hasRecords,
-  topCategoryLabel,
-}: CategoryChartProps) {
+export default function CategoryChart({ categories, hasRecords, summaryText }: CategoryChartProps) {
   const navigate = useNavigate()
   const maxAmount = Math.max(...categories.map((c) => c.amount), 1)
-  const totalAmount = categories.reduce((sum, c) => sum + c.amount, 0)
-  const topPercent =
-    totalAmount > 0 ? Math.round(((categories[0]?.amount ?? 0) / totalAmount) * 100) : 0
 
   return (
     <section className={styles.card}>
@@ -36,12 +29,12 @@ export default function CategoryChart({
           <div className={styles.chartArea}>
             {categories.map((cat) => (
               <div
-                key={cat.label}
+                key={cat.categoryCode}
                 className={styles.barWrapper}
                 onClick={() =>
                   cat.isOther
                     ? navigate('/record?filter=other')
-                    : navigate(`/record?category=${encodeURIComponent(cat.label)}`)
+                    : navigate(`/record?category=${encodeURIComponent(cat.categoryCode)}`)
                 }
                 role="button"
                 tabIndex={0}
@@ -59,10 +52,7 @@ export default function CategoryChart({
               </div>
             ))}
           </div>
-          <p className={styles.message}>
-            이번 달에는 <strong className={styles.messageBold}>{topCategoryLabel}</strong> 소비가
-            전체 지출의 {topPercent}%를 차지했어요.
-          </p>
+          <p className={styles.message}>{summaryText}</p>
         </>
       ) : (
         <div className={styles.emptyState}>

--- a/src/features/home/components/GoalProgress.tsx
+++ b/src/features/home/components/GoalProgress.tsx
@@ -1,15 +1,19 @@
 import { formatKRW } from '@/shared/utils/currency'
+import type { GoalAchievementStatus } from '../types'
 import styles from './GoalProgress.module.css'
 
 interface GoalProgressProps {
-  goalAmount: number | null
-  goalCurrent: number
+  goalStatus: GoalAchievementStatus
+  achievementRate: number
+  remainingAmount: number | null
 }
 
-export default function GoalProgress({ goalAmount, goalCurrent }: GoalProgressProps) {
-  const rawPercent = goalAmount ? Math.round((goalCurrent / goalAmount) * 100) : 0
-  const percent = Math.min(100, rawPercent)
-  const isAchieved = rawPercent >= 100
+export default function GoalProgress({
+  goalStatus,
+  achievementRate,
+  remainingAmount,
+}: GoalProgressProps) {
+  const percent = Math.min(100, Math.max(0, achievementRate))
 
   return (
     <div className={styles.card}>
@@ -31,21 +35,16 @@ export default function GoalProgress({ goalAmount, goalCurrent }: GoalProgressPr
         </div>
       </div>
 
-      <div className={styles.amounts}>
-        <span className={styles.amount}>{formatKRW(goalCurrent)}</span>
-        <span className={styles.amount}>
-          {goalAmount ? `목표 ${formatKRW(goalAmount)}` : '목표 미설정'}
-        </span>
-      </div>
-
-      {goalAmount === null ? (
+      {goalStatus === 'NOT_SET' ? (
         <p className={styles.remaining}>절약 목표를 설정해보세요.</p>
-      ) : isAchieved ? (
+      ) : goalStatus === 'ACHIEVED' ? (
         <p className={styles.remaining}>이번 달 절약 목표를 달성했어요!</p>
       ) : (
         <p className={styles.remaining}>
           목표까지{' '}
-          <strong className={styles.remainingAmount}>{formatKRW(goalAmount - goalCurrent)}</strong>{' '}
+          <strong className={styles.remainingAmount}>
+            {remainingAmount !== null ? formatKRW(remainingAmount) : ''}
+          </strong>{' '}
           남았어요
         </p>
       )}

--- a/src/features/home/components/HomeBanner.tsx
+++ b/src/features/home/components/HomeBanner.tsx
@@ -1,25 +1,26 @@
 import { getFormattedDateLabel } from '@/shared/utils/date'
+import type { GoalAchievementStatus } from '../types'
 import styles from './HomeBanner.module.css'
 
 interface HomeBannerProps {
-  goalSet: boolean
-  achievementPercent: number | null
+  goalStatus: GoalAchievementStatus
+  achievementRate: number
 }
 
-export default function HomeBanner({ goalSet, achievementPercent }: HomeBannerProps) {
+export default function HomeBanner({ goalStatus, achievementRate }: HomeBannerProps) {
   const dateLabel = getFormattedDateLabel()
 
   let line1: string
   let line2: string
 
-  if (!goalSet) {
+  if (goalStatus === 'NOT_SET') {
     line1 = '이번 달 절약 목표를'
     line2 = '설정해보세요.'
-  } else if (achievementPercent !== null && achievementPercent >= 100) {
+  } else if (goalStatus === 'ACHIEVED') {
     line1 = '이번 달 절약 목표를'
     line2 = '달성했어요! 🎉'
   } else {
-    line1 = `이번 달 목표 ${achievementPercent ?? 0}%`
+    line1 = `이번 달 목표 ${achievementRate}%`
     line2 = '달성했어요 🎯'
   }
 

--- a/src/features/home/components/SpendingSummary.tsx
+++ b/src/features/home/components/SpendingSummary.tsx
@@ -1,31 +1,20 @@
 import { useNavigate } from 'react-router-dom'
 import { formatKRW } from '@/shared/utils/currency'
+import type { RemainingBudgetStatus } from '../types'
 import styles from './SpendingSummary.module.css'
 
 interface SpendingSummaryProps {
   monthlySpending: number
-  lastMonthSpending: number | null
-  budget: number | null
+  comparisonRate: number | null
+  comparisonMessage: string | null
+  budgetStatus: RemainingBudgetStatus
+  remainingBudget: number | null
+  budgetMessage: string
 }
 
-function getComparisonLabel(
-  monthlySpending: number,
-  lastMonthSpending: number | null,
-): string | null {
-  if (lastMonthSpending === null || lastMonthSpending === 0) return null
-  const percent = Math.round(((monthlySpending - lastMonthSpending) / lastMonthSpending) * 100)
-  if (percent === 0) return '지난달과 같아요'
-  return `지난 달보다 ${percent > 0 ? '+' : ''}${percent}%`
-}
-
-function getSpendingTrend(
-  monthlySpending: number,
-  lastMonthSpending: number | null,
-): 'up' | 'down' | 'none' {
-  if (lastMonthSpending === null || lastMonthSpending === 0) return 'none'
-  if (monthlySpending > lastMonthSpending) return 'up'
-  if (monthlySpending < lastMonthSpending) return 'down'
-  return 'none'
+function getSpendingTrend(comparisonRate: number | null): 'up' | 'down' | 'none' {
+  if (!comparisonRate) return 'none'
+  return comparisonRate > 0 ? 'up' : 'down'
 }
 
 function UpArrowIcon({ color }: { color: string }) {
@@ -72,30 +61,18 @@ function DownArrowIcon({ color }: { color: string }) {
 
 export default function SpendingSummary({
   monthlySpending,
-  lastMonthSpending,
-  budget,
+  comparisonRate,
+  comparisonMessage,
+  budgetStatus,
+  remainingBudget,
+  budgetMessage,
 }: SpendingSummaryProps) {
   const navigate = useNavigate()
-  const comparisonLabel = getComparisonLabel(monthlySpending, lastMonthSpending)
-  const spendingTrend = getSpendingTrend(monthlySpending, lastMonthSpending)
+  const spendingTrend = getSpendingTrend(comparisonRate)
 
-  const isBudgetUnset = budget === null
-  const remaining = budget !== null ? budget - monthlySpending : null
-  const isOverBudget = remaining !== null && remaining < 0
-
-  let budgetAmount: string
-  let budgetSub: string
-
-  if (isBudgetUnset) {
-    budgetAmount = ''
-    budgetSub = '이번 달 예산을 설정해주세요.'
-  } else if (isOverBudget) {
-    budgetAmount = formatKRW(Math.abs(remaining!))
-    budgetSub = `예산을 ${formatKRW(Math.abs(remaining!))} 초과했어요`
-  } else {
-    budgetAmount = formatKRW(remaining!)
-    budgetSub = '목표까지 남았어요'
-  }
+  const isBudgetUnset = budgetStatus === 'NOT_SET'
+  const isOverBudget = budgetStatus === 'EXCEEDED'
+  const budgetAmount = remainingBudget !== null ? formatKRW(Math.abs(remainingBudget)) : ''
 
   return (
     <div className={styles.wrapper}>
@@ -107,7 +84,7 @@ export default function SpendingSummary({
           {spendingTrend === 'down' && <DownArrowIcon color="#2946D8" />}
           <p className={styles.amountRed}>{formatKRW(monthlySpending)}</p>
         </div>
-        {comparisonLabel && <p className={styles.sub}>{comparisonLabel}</p>}
+        {comparisonMessage && <p className={styles.sub}>{comparisonMessage}</p>}
       </div>
 
       {/* 남은 예산 */}
@@ -138,7 +115,7 @@ export default function SpendingSummary({
             </p>
           </div>
         )}
-        <p className={styles.sub}>{budgetSub}</p>
+        <p className={styles.sub}>{budgetMessage}</p>
       </div>
     </div>
   )

--- a/src/features/home/index.tsx
+++ b/src/features/home/index.tsx
@@ -27,37 +27,42 @@ export default function Home() {
   if (!data) return null
 
   const {
+    goalStatus,
+    achievementRate,
+    achievementRemainingAmount,
     monthlySpending,
-    lastMonthSpending,
-    budget,
-    goalAmount,
-    goalCurrent,
+    comparisonRate,
+    comparisonMessage,
+    budgetStatus,
+    remainingBudget,
+    budgetMessage,
     categories,
+    categorySummaryText,
     hasRecords,
   } = data
 
-  const achievementPercent = goalAmount
-    ? Math.min(100, Math.round((goalCurrent / goalAmount) * 100))
-    : null
-
-  const topCategory = categories[0]
-  const topCategoryLabel = topCategory?.label ?? ''
-
   return (
     <main className={styles.main}>
-      <HomeBanner goalSet={goalAmount !== null} achievementPercent={achievementPercent} />
+      <HomeBanner goalStatus={goalStatus} achievementRate={achievementRate} />
       <div className={styles.content}>
         <CategoryChart
           categories={categories}
           hasRecords={hasRecords}
-          topCategoryLabel={topCategoryLabel}
+          summaryText={categorySummaryText}
         />
         <SpendingSummary
           monthlySpending={monthlySpending}
-          lastMonthSpending={lastMonthSpending}
-          budget={budget}
+          comparisonRate={comparisonRate}
+          comparisonMessage={comparisonMessage}
+          budgetStatus={budgetStatus}
+          remainingBudget={remainingBudget}
+          budgetMessage={budgetMessage}
         />
-        <GoalProgress goalAmount={goalAmount} goalCurrent={goalCurrent} />
+        <GoalProgress
+          goalStatus={goalStatus}
+          achievementRate={achievementRate}
+          remainingAmount={achievementRemainingAmount}
+        />
         <EncouragementCard />
         <SpendingQuestion />
       </div>

--- a/src/features/home/types.ts
+++ b/src/features/home/types.ts
@@ -1,16 +1,26 @@
+export type GoalAchievementStatus = 'NOT_SET' | 'IN_PROGRESS' | 'ACHIEVED'
+export type RemainingBudgetStatus = 'NOT_SET' | 'WITHIN' | 'EXCEEDED'
+
 export interface CategoryData {
+  categoryCode: string
   label: string
   amount: number
+  ratio: number
   color: string
   isOther: boolean
 }
 
 export interface HomeData {
+  goalStatus: GoalAchievementStatus
+  achievementRate: number
+  achievementRemainingAmount: number | null
   monthlySpending: number
-  lastMonthSpending: number | null
-  budget: number | null
-  goalAmount: number | null
-  goalCurrent: number
+  comparisonRate: number | null
+  comparisonMessage: string | null
+  budgetStatus: RemainingBudgetStatus
+  remainingBudget: number | null
+  budgetMessage: string
   categories: CategoryData[]
+  categorySummaryText: string
   hasRecords: boolean
 }


### PR DESCRIPTION

## 📌 작업 내용

- src/features/home/types.ts — API 응답 구조에 맞춰 타입 재정의
- HomeBanner — "이번 달 목표 ~% 달성했어요" 배너를 goalStatus(NOT_SET/IN_PROGRESS/ACHIEVED) 기반으로 연동
- GoalProgress — 목표 달성률 progress bar를 rate, 남은 금액을 remainingAmount로 연동
- SpendingSummary — 이번 달 지출, 지난달 대비 증감(comparisonMessage), 남은 예산(budgetMessage)을 API 응답 그대로 표시하도록 연동 (프론트에서 직접 계산하던 로직 제거)
- CategoryChart — 카테고리별 지출 막대그래프와 요약 문구(summaryText)를 API 응답으로 연동, 카드 클릭 시 이동 파라미터를 카테고리 코드 기준으로 변경

## 📷 스크린 샷

-

## ⚠️ 참고 사항

-

## 🔗 관련 이슈

Closes #134 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 홈 화면이 목 데이터 대신 실제 서버 데이터를 표시합니다.
  * 목표 달성률, 남은 금액, 전월 대비 지출, 예산 상태를 확인할 수 있습니다.
  * 지출 카테고리 차트에 요약 문구와 상세 카테고리 정보가 반영됩니다.

* **개선 사항**
  * 목표 미설정·달성·진행 중 상태에 따른 안내 문구가 제공됩니다.
  * 예산 초과 및 잔여 예산 상태가 더욱 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->