### PR TITLE
✨ [Feature] 비밀번호 재설정 api 연동

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -234,6 +234,10 @@ export interface PasswordResetRequest {
 export interface PasswordResetResponse {
   success: boolean
   message: string
+  data: {
+    codeTtlSeconds: number
+    resendCooldownSeconds: number
+  }
 }
 
 export const requestPasswordReset = async (
@@ -249,8 +253,10 @@ export const requestPasswordReset = async (
 
 //비밀번호 재설정 완료
 export interface PasswordResetConfirmRequest {
-  token: string
+  email: string
+  code: string
   newPassword: string
+  newPasswordConfirm: string
 }
 
 export interface PasswordResetConfirmResponse {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -225,3 +225,46 @@ export const confirmKakaoLinkEmail = async (
 
   return data
 }
+
+// 비밀번호 재설정 요청
+export interface PasswordResetRequest {
+  email: string
+}
+
+export interface PasswordResetResponse {
+  success: boolean
+  message: string
+}
+
+export const requestPasswordReset = async (
+  body: PasswordResetRequest,
+): Promise<PasswordResetResponse> => {
+  const { data } = await client.post<PasswordResetResponse>(
+    '/api/v1/auth/password-reset/request',
+    body,
+  )
+
+  return data
+}
+
+//비밀번호 재설정 완료
+export interface PasswordResetConfirmRequest {
+  token: string
+  newPassword: string
+}
+
+export interface PasswordResetConfirmResponse {
+  success: boolean
+  message: string
+}
+
+export const confirmPasswordReset = async (
+  body: PasswordResetConfirmRequest,
+): Promise<PasswordResetConfirmResponse> => {
+  const { data } = await client.patch<PasswordResetConfirmResponse>(
+    '/api/v1/auth/password-reset/confirm',
+    body,
+  )
+
+  return data
+}

--- a/src/features/auth/ResetPasswordNew.tsx
+++ b/src/features/auth/ResetPasswordNew.tsx
@@ -7,24 +7,32 @@ import AuthLayout from './components/AuthLayout'
 import AuthPageHeader from './components/AuthPageHeader'
 import { clearResetPasswordDraft, getResetPasswordDraft } from './resetPasswordSession'
 import { usePasswordResetConfirm } from '@/hooks/usePasswordResetConfirm'
-import { AxiosError } from 'axios'
+import { isAxiosError } from 'axios'
 
+// 백엔드는 특정 특수문자 목록이 아니라 "영문/숫자가 아닌 문자"면 뭐든 허용합니다.
+// 특정 목록으로 제한하면 백엔드는 받아줄 비밀번호를 프론트가 먼저 막게 됩니다.
 const isValidPassword = (value: string) =>
-  /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>]).{8,}$/.test(value)
+  /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,100}$/.test(value)
 
 export default function ResetPasswordNew() {
   const navigate = useNavigate()
   const { mutate: confirmPasswordReset } = usePasswordResetConfirm()
-  const draft = getResetPasswordDraft()
+
+  // 마운트 시 1회만 읽습니다. 매 렌더마다 새로 읽으면, 제출 성공 후 draft를 지운 뒤
+  // (목적지 라우트가 lazy라 전환이 비동기라서) 언마운트 전에 한 번 더 렌더될 때
+  // 가드가 빈 draft를 보고 navigate('/login')을 덮어쓰며 여기로 되돌아오는 문제가 있었습니다.
+  const [draft] = useState(() => getResetPasswordDraft())
 
   const [password, setPassword] = useState('')
   const [passwordCheck, setPasswordCheck] = useState('')
   const [error, setError] = useState('')
 
   // 이메일 인증을 거치지 않고 바로 들어오면 재설정 요청 화면으로 돌려보냅니다.
-  if (!draft.email || !draft.codeVerified) {
+  if (!draft.email || !draft.code || !draft.codeVerified) {
     return <Navigate to="/reset-password" replace />
   }
+
+  const { email, code } = draft
 
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault()
@@ -39,11 +47,12 @@ export default function ResetPasswordNew() {
       return
     }
 
-    // TODO: API 연동 시 실제 비밀번호 변경 요청으로 교체
     confirmPasswordReset(
       {
-        token: '', // TODO: 인증 API에서 받은 token으로 교체
+        email,
+        code,
         newPassword: password,
+        newPasswordConfirm: passwordCheck,
       },
       {
         onSuccess: () => {
@@ -51,8 +60,20 @@ export default function ResetPasswordNew() {
           navigate('/login')
         },
 
-        onError: (error: AxiosError<{ message: string }>) => {
-          setError(error.response?.data.message ?? '비밀번호 변경에 실패했습니다.')
+        onError: (error: unknown) => {
+          if (!isAxiosError<{ message?: string; retryAfterSeconds?: number }>(error)) {
+            setError('비밀번호 변경에 실패했습니다.')
+            return
+          }
+
+          const body = error.response?.data
+          const base = body?.message ?? '비밀번호 변경에 실패했습니다.'
+
+          setError(
+            error.response?.status === 429 && body?.retryAfterSeconds
+              ? `${base} (${body.retryAfterSeconds}초 후 다시 시도해주세요.)`
+              : base,
+          )
         },
       },
     )

--- a/src/features/auth/ResetPasswordNew.tsx
+++ b/src/features/auth/ResetPasswordNew.tsx
@@ -6,12 +6,15 @@ import Button from '@/shared/components/Button'
 import AuthLayout from './components/AuthLayout'
 import AuthPageHeader from './components/AuthPageHeader'
 import { clearResetPasswordDraft, getResetPasswordDraft } from './resetPasswordSession'
+import { usePasswordResetConfirm } from '@/hooks/usePasswordResetConfirm'
+import { AxiosError } from 'axios'
 
 const isValidPassword = (value: string) =>
   /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>]).{8,}$/.test(value)
 
 export default function ResetPasswordNew() {
   const navigate = useNavigate()
+  const { mutate: confirmPasswordReset } = usePasswordResetConfirm()
   const draft = getResetPasswordDraft()
 
   const [password, setPassword] = useState('')
@@ -37,9 +40,22 @@ export default function ResetPasswordNew() {
     }
 
     // TODO: API 연동 시 실제 비밀번호 변경 요청으로 교체
-    setError('')
-    clearResetPasswordDraft()
-    navigate('/login')
+    confirmPasswordReset(
+      {
+        token: '', // TODO: 인증 API에서 받은 token으로 교체
+        newPassword: password,
+      },
+      {
+        onSuccess: () => {
+          clearResetPasswordDraft()
+          navigate('/login')
+        },
+
+        onError: (error: AxiosError<{ message: string }>) => {
+          setError(error.response?.data.message ?? '비밀번호 변경에 실패했습니다.')
+        },
+      },
+    )
   }
 
   return (

--- a/src/features/auth/ResetPasswordRequest.tsx
+++ b/src/features/auth/ResetPasswordRequest.tsx
@@ -7,9 +7,14 @@ import AuthLayout from './components/AuthLayout'
 import AuthPageHeader from './components/AuthPageHeader'
 import { saveResetPasswordDraft } from './resetPasswordSession'
 import { usePasswordResetRequest } from '@/hooks/usePasswordResetRequest'
-import { AxiosError } from 'axios'
+import { isAxiosError } from 'axios'
 
 const isValidEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+
+interface RateLimitErrorBody {
+  message?: string
+  retryAfterSeconds?: number
+}
 
 export default function ResetPasswordRequest() {
   const navigate = useNavigate()
@@ -38,17 +43,26 @@ export default function ResetPasswordRequest() {
           navigate('/reset-password/verify')
         },
 
-        onError: (error: AxiosError) => {
+        onError: (error: unknown) => {
           console.error(error)
+
+          if (!isAxiosError<RateLimitErrorBody>(error)) {
+            setError('비밀번호 재설정 요청에 실패했습니다.')
+            return
+          }
 
           const status = error.response?.status
 
+          // 계정 존재 여부를 노출하지 않기 위해 이 API는 이메일이 없어도 항상 200을
+          // 반환하도록 설계돼 있어(스펙 설명 참고), 404는 여기서 절대 오지 않습니다.
+          // 만에 하나 실제로 온다면 "가입되지 않은 이메일" 같은 문구로 계정 존재 여부를
+          // 노출하면 안 되므로 일부러 일반 실패 메시지로 처리합니다.
           if (status === 400) {
             setError('올바른 이메일 형식이 아닙니다.')
-          } else if (status === 404) {
-            setError('가입되지 않은 이메일입니다.')
-          } else if (status === 501) {
-            setError('비밀번호 재설정 기능이 아직 지원되지 않습니다.')
+          } else if (status === 429) {
+            const retry = error.response?.data.retryAfterSeconds
+            const base = error.response?.data.message ?? '요청이 너무 잦습니다.'
+            setError(retry ? `${base} (${retry}초 후 다시 시도해주세요.)` : base)
           } else {
             setError('비밀번호 재설정 요청에 실패했습니다.')
           }

--- a/src/features/auth/ResetPasswordRequest.tsx
+++ b/src/features/auth/ResetPasswordRequest.tsx
@@ -6,11 +6,14 @@ import Button from '@/shared/components/Button'
 import AuthLayout from './components/AuthLayout'
 import AuthPageHeader from './components/AuthPageHeader'
 import { saveResetPasswordDraft } from './resetPasswordSession'
+import { usePasswordResetRequest } from '@/hooks/usePasswordResetRequest'
+import { AxiosError } from 'axios'
 
 const isValidEmail = (value: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
 
 export default function ResetPasswordRequest() {
   const navigate = useNavigate()
+  const { mutate: requestPasswordReset } = usePasswordResetRequest()
   const [email, setEmail] = useState('')
   const [error, setError] = useState('')
 
@@ -23,8 +26,35 @@ export default function ResetPasswordRequest() {
     }
 
     // TODO: API 연동 시 실제 일회용 코드 발송 요청으로 교체
-    saveResetPasswordDraft({ email, codeVerified: false })
-    navigate('/reset-password/verify')
+    requestPasswordReset(
+      { email },
+      {
+        onSuccess: () => {
+          saveResetPasswordDraft({
+            email,
+            codeVerified: false,
+          })
+
+          navigate('/reset-password/verify')
+        },
+
+        onError: (error: AxiosError) => {
+          console.error(error)
+
+          const status = error.response?.status
+
+          if (status === 400) {
+            setError('올바른 이메일 형식이 아닙니다.')
+          } else if (status === 404) {
+            setError('가입되지 않은 이메일입니다.')
+          } else if (status === 501) {
+            setError('비밀번호 재설정 기능이 아직 지원되지 않습니다.')
+          } else {
+            setError('비밀번호 재설정 요청에 실패했습니다.')
+          }
+        },
+      },
+    )
   }
 
   return (

--- a/src/features/auth/ResetPasswordVerify.tsx
+++ b/src/features/auth/ResetPasswordVerify.tsx
@@ -31,9 +31,10 @@ export default function ResetPasswordVerify() {
       return
     }
 
-    // TODO: API 연동 시 실제 인증 코드 확인 요청으로 교체
+    // 코드 단독 검증 API가 없어(백엔드가 비밀번호 변경과 함께 원자적으로 검증), 여기서는
+    // 형식만 확인하고 코드를 보관해뒀다가 다음 화면에서 새 비밀번호와 함께 제출합니다.
     setError('')
-    saveResetPasswordDraft({ codeVerified: true })
+    saveResetPasswordDraft({ code, codeVerified: true })
     navigate('/reset-password/new')
   }
 

--- a/src/features/auth/resetPasswordSession.ts
+++ b/src/features/auth/resetPasswordSession.ts
@@ -2,6 +2,7 @@ const KEY = 'reset_password_draft'
 
 export interface ResetPasswordDraft {
   email?: string
+  code?: string
   codeVerified?: boolean
 }
 
@@ -12,9 +13,10 @@ export function getResetPasswordDraft(): ResetPasswordDraft {
 
     // 필드별로 타입을 검증합니다. 값이 null이거나 형태가 어긋나면
     // draft.email 등에 접근하는 화면(ResetPasswordVerify/New)이 가드보다 먼저 오류를 낼 수 있습니다.
-    const { email, codeVerified } = parsed as Record<string, unknown>
+    const { email, code, codeVerified } = parsed as Record<string, unknown>
     return {
       email: typeof email === 'string' ? email : undefined,
+      code: typeof code === 'string' ? code : undefined,
       codeVerified: typeof codeVerified === 'boolean' ? codeVerified : undefined,
     }
   } catch {

--- a/src/hooks/usePasswordResetConfirm.ts
+++ b/src/hooks/usePasswordResetConfirm.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query'
+import { confirmPasswordReset } from '@/api/auth'
+
+export const usePasswordResetConfirm = () => {
+  return useMutation({
+    mutationFn: confirmPasswordReset,
+  })
+}

--- a/src/hooks/usePasswordResetRequest.ts
+++ b/src/hooks/usePasswordResetRequest.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query'
+import { requestPasswordReset } from '@/api/auth'
+
+export const usePasswordResetRequest = () => {
+  return useMutation({
+    mutationFn: requestPasswordReset,
+  })
+}


### PR DESCRIPTION
## 📌 작업 내용

### 비밀번호 재설정 요청 API 연동
- POST /api/v1/auth/password-reset/request 연동
- React Query Hook(usePasswordResetRequest) 추가
- ResetPasswordRequest 화면 API 연결
- 성공 시 인증 화면으로 이동하도록 수정

### 비밀번호 재설정 완료 API 연동
- PATCH /api/v1/auth/password-reset/confirm API 추가
- React Query Hook(usePasswordResetConfirm) 추가
- ResetPasswordNew 화면 API 연결
- 성공 시 로그인 화면으로 이동하도록 수정

## 📷 스크린 샷

-

## ⚠️ 참고 사항


## 🔗 관련 이슈

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 이메일을 통한 비밀번호 재설정 요청 기능을 추가했습니다.
  * 인증 코드 확인 및 새 비밀번호 설정 기능을 제공합니다.
  * 재전송 제한 시간과 인증 코드 만료 시간을 안내합니다.
  * 오류 유형과 재시도 가능 시간을 구분해 표시합니다.
  * 비밀번호 입력 시 최대 길이 및 문자 조건 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->