### PR TITLE
✨ [Feature] 위시리스트 상세 조회/수정 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -456,6 +457,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -504,6 +506,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -523,16 +526,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1562,8 +1555,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1673,6 +1665,7 @@
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1683,6 +1676,7 @@
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1693,6 +1687,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1748,6 +1743,7 @@
       "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -2091,6 +2087,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2143,7 +2140,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2154,7 +2150,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2266,6 +2261,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2628,8 +2624,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2769,6 +2764,7 @@
       "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3880,7 +3876,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4195,7 +4190,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4210,8 +4204,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -4237,6 +4230,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4246,6 +4240,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4274,6 +4269,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -4378,7 +4374,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4708,6 +4705,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4834,6 +4832,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5146,6 +5145,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "donworry-fe",
       "version": "0.0.0",
       "dependencies": {
+        "@emnapi/runtime": "^1.11.3",
         "@iconify/react": "^6.0.2",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/react-query": "^5.101.0",
@@ -528,6 +529,16 @@
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "*.{ts,tsx,css}": "prettier --write"
   },
   "dependencies": {
+    "@emnapi/runtime": "^1.11.3",
     "@iconify/react": "^6.0.2",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/react-query": "^5.101.0",

--- a/src/features/temptation/api/wishlistApi.ts
+++ b/src/features/temptation/api/wishlistApi.ts
@@ -92,8 +92,33 @@ export const fetchWishlistItems = async (): Promise<Product[]> => {
   return data.data.map(mapToProduct).filter((p): p is Product => p !== null)
 }
 
+export const fetchWishlistItem = async (id: string): Promise<Product> => {
+  const { data } = await client.get<WishlistItemApiResponse>(`/api/v1/wishlist-items/${id}`)
+  const product = mapToProduct(data.data)
+  if (!product) {
+    throw new Error('Failed to map the response to Product')
+  }
+  return product
+}
+
 export const addWishlistItem = async (formData: WishFormData): Promise<Product> => {
   const { data } = await client.post<WishlistItemApiResponse>('/api/v1/wishlist-items', {
+    categoryCode: CATEGORY_TO_CODE_MAP[formData.category],
+    productName: formData.name,
+    productUrl: formData.link,
+    price: formData.price,
+    reason: formData.reason,
+    waitType: TIME_TO_WAIT_TYPE_MAP[formData.time],
+  })
+  const product = mapToProduct(data.data)
+  if (!product) {
+    throw new Error('Failed to map the response to Product')
+  }
+  return product
+}
+
+export const updateWishlistItem = async (id: string, formData: WishFormData): Promise<Product> => {
+  const { data } = await client.patch<WishlistItemApiResponse>(`/api/v1/wishlist-items/${id}`, {
     categoryCode: CATEGORY_TO_CODE_MAP[formData.category],
     productName: formData.name,
     productUrl: formData.link,

--- a/src/features/temptation/api/wishlistApi.ts
+++ b/src/features/temptation/api/wishlistApi.ts
@@ -1,8 +1,8 @@
-import axios from 'axios'
 import client from '@/api/client'
 import type { Product } from '../types'
 import { CATEGORIES, TIME_OPTIONS } from '@/constants/product'
 import type { FormData as WishFormData } from '@/components/layout/ProductForm'
+import { getWishlistErrorKind } from '../utils/wishlistErrors'
 
 interface WishlistItemResponse {
   id: string
@@ -88,34 +88,28 @@ const mapToProduct = (item: WishlistItemResponse): Product => {
   }
 }
 
-export const fetchWishlistItems = async (): Promise<Product[]> => {
-  const { data } = await client.get<WishlistItemsApiResponse>('/api/v1/wishlist-items')
-  return data.data.map(mapToProduct).filter((p): p is Product => p !== null)
-}
-
-export const fetchWishlistItem = async (id: string): Promise<Product> => {
+const wishlistErrorHandling = async <T>(request: () => Promise<T>): Promise<T> => {
   try {
-    const { data } = await client.get<WishlistItemApiResponse>(`/api/v1/wishlist-items/${id}`)
-    const product = mapToProduct(data.data)
-    if (!product) {
-      throw new Error('Failed to map the response to Product')
-    }
-    return product
+    return await request()
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const errorCode = error.response.data?.code
-      if (errorCode === 'WISH4001') {
-        throw new Error('EMPTY', { cause: error })
-      }
-      if (errorCode === 'WISH4031') {
-        throw new Error('FORBIDDEN', { cause: error })
-      }
-      if (errorCode === 'WISH4041') {
-        throw new Error('NOT_FOUND', { cause: error })
-      }
+    const kind = getWishlistErrorKind(error)
+    if (kind) {
+      throw new Error(kind, { cause: error })
     }
     throw error
   }
+}
+
+export const fetchWishlistItems = async (): Promise<Product[]> => {
+  const { data } = await client.get<WishlistItemsApiResponse>('/api/v1/wishlist-items')
+  return data.data.map(mapToProduct)
+}
+
+export const fetchWishlistItem = async (id: string): Promise<Product> => {
+  return wishlistErrorHandling(async () => {
+    const { data } = await client.get<WishlistItemApiResponse>(`/api/v1/wishlist-items/${id}`)
+    return mapToProduct(data.data)
+  })
 }
 
 export const addWishlistItem = async (formData: WishFormData): Promise<Product> => {
@@ -127,25 +121,19 @@ export const addWishlistItem = async (formData: WishFormData): Promise<Product> 
     reason: formData.reason,
     waitType: TIME_TO_WAIT_TYPE_MAP[formData.time],
   })
-  const product = mapToProduct(data.data)
-  if (!product) {
-    throw new Error('Failed to map the response to Product')
-  }
-  return product
+  return mapToProduct(data.data)
 }
 
 export const updateWishlistItem = async (id: string, formData: WishFormData): Promise<Product> => {
-  const { data } = await client.patch<WishlistItemApiResponse>(`/api/v1/wishlist-items/${id}`, {
-    categoryCode: CATEGORY_TO_CODE_MAP[formData.category],
-    productName: formData.name,
-    productUrl: formData.link,
-    price: formData.price,
-    reason: formData.reason,
-    waitType: TIME_TO_WAIT_TYPE_MAP[formData.time],
+  return wishlistErrorHandling(async () => {
+    const { data } = await client.patch<WishlistItemApiResponse>(`/api/v1/wishlist-items/${id}`, {
+      categoryCode: CATEGORY_TO_CODE_MAP[formData.category],
+      productName: formData.name,
+      productUrl: formData.link,
+      price: formData.price,
+      reason: formData.reason,
+      waitType: TIME_TO_WAIT_TYPE_MAP[formData.time],
+    })
+    return mapToProduct(data.data)
   })
-  const product = mapToProduct(data.data)
-  if (!product) {
-    throw new Error('Failed to map the response to Product')
-  }
-  return product
 }

--- a/src/features/temptation/api/wishlistApi.ts
+++ b/src/features/temptation/api/wishlistApi.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import client from '@/api/client'
 import type { Product } from '../types'
 import { CATEGORIES, TIME_OPTIONS } from '@/constants/product'
@@ -93,12 +94,28 @@ export const fetchWishlistItems = async (): Promise<Product[]> => {
 }
 
 export const fetchWishlistItem = async (id: string): Promise<Product> => {
-  const { data } = await client.get<WishlistItemApiResponse>(`/api/v1/wishlist-items/${id}`)
-  const product = mapToProduct(data.data)
-  if (!product) {
-    throw new Error('Failed to map the response to Product')
+  try {
+    const { data } = await client.get<WishlistItemApiResponse>(`/api/v1/wishlist-items/${id}`)
+    const product = mapToProduct(data.data)
+    if (!product) {
+      throw new Error('Failed to map the response to Product')
+    }
+    return product
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const errorCode = error.response.data?.code
+      if (errorCode === 'WISH4001') {
+        throw new Error('EMPTY', { cause: error })
+      }
+      if (errorCode === 'WISH4031') {
+        throw new Error('FORBIDDEN', { cause: error })
+      }
+      if (errorCode === 'WISH4041') {
+        throw new Error('NOT_FOUND', { cause: error })
+      }
+    }
+    throw error
   }
-  return product
 }
 
 export const addWishlistItem = async (formData: WishFormData): Promise<Product> => {

--- a/src/features/temptation/hooks/useWishlist.ts
+++ b/src/features/temptation/hooks/useWishlist.ts
@@ -1,17 +1,10 @@
 import { useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { CATEGORIES, TIME_OPTIONS } from '@/constants/product'
-import type { Category, FilterValue, SortValue, Product } from '../types'
+import type { Category, FilterValue, SortValue } from '../types'
 import type { FormData as WishFormData } from '@/components/layout/ProductForm'
-import { fetchWishlistItems, addWishlistItem } from '../api/wishlistApi'
+import { fetchWishlistItems, addWishlistItem, updateWishlistItem } from '../api/wishlistApi'
 import { isUnauthorizedError } from '../utils/isUnauthorizedError'
-
-const TIME_TO_HOURS: Record<(typeof TIME_OPTIONS)[number], number> = {
-  '1시간': 1,
-  '1일': 24,
-  '3일': 72,
-  '7일': 168,
-}
 
 export const useWishlist = () => {
   const queryClient = useQueryClient()
@@ -26,17 +19,14 @@ export const useWishlist = () => {
     queryFn: fetchWishlistItems,
   })
 
-  // 수정/삭제 등 연동 전 API에 대한 임시 방편
+  // 연동 전 API에 대한 임시 방편
   // 연동 후 해당 부분 삭제, serverProducts를 직접 사용하도록 변경
-  const [localOverrides, setLocalOverrides] = useState<{
-    deletedIds: Set<string>
-    edited: Map<string, Product>
-  }>({ deletedIds: new Set(), edited: new Map() })
+  const [localOverrides, setLocalOverrides] = useState<{ deletedIds: Set<string> }>({
+    deletedIds: new Set(),
+  })
 
   const products = useMemo(() => {
-    return serverProducts
-      .filter((p) => !localOverrides.deletedIds.has(p.id))
-      .map((p) => localOverrides.edited.get(p.id) ?? p)
+    return serverProducts.filter((p) => !localOverrides.deletedIds.has(p.id))
   }, [serverProducts, localOverrides])
 
   const [filter, setFilter] = useState<FilterValue>('전체')
@@ -66,9 +56,8 @@ export const useWishlist = () => {
   })
 
   const handleDelete = (id: string) => {
-    console.warn(`API 연동 전! (id: ${id}) 다다음 이슈에서 작업 예정`)
+    console.warn(`API 연동 전! (id: ${id}) 다음 이슈에서 작업 예정`)
     setLocalOverrides((prev) => ({
-      ...prev,
       deletedIds: new Set(prev.deletedIds).add(id),
     }))
   }
@@ -77,58 +66,50 @@ export const useWishlist = () => {
     addMutation.mutate(formData)
   }
 
+  const extendMutation = useMutation({
+    mutationFn: ({ id, formData }: { id: string; formData: WishFormData }) =>
+      updateWishlistItem(id, formData),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['wishlistItems'] })
+    },
+  })
+
   const handleExtend = (id: string, timeOption: (typeof TIME_OPTIONS)[number]) => {
-    console.warn(`API 연동 전! (id: ${id}, timeOption: ${timeOption})`)
     const target = products.find((p) => p.id === id)
     if (!target) return
 
-    const updated: Product = {
-      ...target,
-      // 연장 시점을 새 기준으로 삼아 남은 시간 게이지와 수정 화면이 함께 맞도록
-      // time/timeOption/createdAt을 모두 갱신
-      time: new Date(Date.now() + TIME_TO_HOURS[timeOption] * 60 * 60 * 1000),
-      timeOption,
-      createdAt: new Date(),
-    }
-
-    setLocalOverrides((prev) => ({
-      ...prev,
-      edited: new Map(prev.edited).set(id, updated),
-    }))
+    extendMutation.mutate({
+      id,
+      formData: {
+        link: target.link ?? undefined,
+        price: target.price,
+        name: target.name,
+        category: target.category,
+        time: timeOption,
+        reason: target.reason ?? '',
+      },
+    })
   }
 
-  const handleEdit = (id: string, formData: WishFormData, timeChanged: boolean) => {
-    console.warn(
-      `API 연동 전! (id: ${id}, formData: ${JSON.stringify(formData)}, timeChanged: ${timeChanged})`,
-    )
-    const target = products.find((p) => p.id === id)
-    if (!target) return
+  const editMutation = useMutation({
+    mutationFn: ({ id, formData }: { id: string; formData: WishFormData }) =>
+      updateWishlistItem(id, formData),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['wishlistItems'] })
+    },
+  })
 
-    const newTime = timeChanged
-      ? // 남은 고민 시간 수정 로직
-        new Date(Date.now() + TIME_TO_HOURS[formData.time] * 60 * 60 * 1000)
-      : target.time
-
-    const updated: Product = {
-      ...target,
-      name: formData.name,
-      price: formData.price,
-      time: newTime,
-      timeOption: formData.time,
-      category: formData.category,
-      link: formData.link,
-      reason: formData.reason,
-    }
-
-    setLocalOverrides((prev) => ({
-      ...prev,
-      edited: new Map(prev.edited).set(id, updated),
-    }))
+  const handleEdit = (id: string, formData: WishFormData) => {
+    editMutation.mutate({ id, formData })
   }
 
   const categoriesToRender: Category[] = filter === '전체' ? [...CATEGORIES] : [filter]
 
-  const isUnauthorized = isUnauthorizedError(error) || isUnauthorizedError(addMutation.error)
+  const isUnauthorized =
+    isUnauthorizedError(error) ||
+    isUnauthorizedError(addMutation.error) ||
+    isUnauthorizedError(editMutation.error) ||
+    isUnauthorizedError(extendMutation.error)
 
   return {
     keyword,
@@ -142,6 +123,14 @@ export const useWishlist = () => {
     isLoading,
     isError,
     isAdding: addMutation.isPending,
+    isEditing: editMutation.isPending,
+    isEditSuccess: editMutation.isSuccess,
+    isEditError: editMutation.isError,
+    resetEditStatus: editMutation.reset,
+    isExtending: extendMutation.isPending,
+    isExtendSuccess: extendMutation.isSuccess,
+    isExtendError: extendMutation.isError,
+    resetExtendStatus: extendMutation.reset,
     isUnauthorized,
     handleDelete,
     handleAdd,

--- a/src/features/temptation/hooks/useWishlist.ts
+++ b/src/features/temptation/hooks/useWishlist.ts
@@ -5,6 +5,7 @@ import type { Category, FilterValue, SortValue } from '../types'
 import type { FormData as WishFormData } from '@/components/layout/ProductForm'
 import { fetchWishlistItems, addWishlistItem, updateWishlistItem } from '../api/wishlistApi'
 import { isUnauthorizedError } from '../utils/isUnauthorizedError'
+import { getMutationErrorKind } from '../utils/wishlistErrors'
 
 export const useWishlist = () => {
   const queryClient = useQueryClient()
@@ -111,6 +112,8 @@ export const useWishlist = () => {
     isUnauthorizedError(editMutation.error) ||
     isUnauthorizedError(extendMutation.error)
 
+  const editErrorKind = getMutationErrorKind(editMutation.error) // 'EMPTY' | 'FORBIDDEN' | 'NOT_FOUND' | null
+
   return {
     keyword,
     setKeyword,
@@ -126,6 +129,7 @@ export const useWishlist = () => {
     isEditing: editMutation.isPending,
     isEditSuccess: editMutation.isSuccess,
     isEditError: editMutation.isError,
+    editErrorKind,
     resetEditStatus: editMutation.reset,
     isExtending: extendMutation.isPending,
     isExtendSuccess: extendMutation.isSuccess,

--- a/src/features/temptation/hooks/useWishlist.ts
+++ b/src/features/temptation/hooks/useWishlist.ts
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { CATEGORIES, TIME_OPTIONS } from '@/constants/product'
-import type { Category, FilterValue, SortValue } from '../types'
+import type { Category, FilterValue, SortValue, Product } from '../types'
 import type { FormData as WishFormData } from '@/components/layout/ProductForm'
 import { fetchWishlistItems, addWishlistItem, updateWishlistItem } from '../api/wishlistApi'
 import { isUnauthorizedError } from '../utils/isUnauthorizedError'
@@ -56,6 +56,16 @@ export const useWishlist = () => {
     },
   })
 
+  // 목록 캐시를 서버 재조회 없이 즉시 갱신합니다.
+  // invalidateQueries만 쓰면 재조회가 끝나기 전까지 목록에 남은 이전 값(예: 지난 고민 시간)을
+  // 상세/재판단 화면이 그대로 읽어 서로를 오가며 화면이 튀는 문제가 있었습니다.
+  const patchWishlistItemCache = (updated: Product) => {
+    queryClient.setQueryData<Product[]>(['wishlistItems'], (old) =>
+      old?.map((p) => (p.id === updated.id ? updated : p)),
+    )
+    queryClient.invalidateQueries({ queryKey: ['wishlistItems'] })
+  }
+
   const handleDelete = (id: string) => {
     console.warn(`API 연동 전! (id: ${id}) 다음 이슈에서 작업 예정`)
     setLocalOverrides((prev) => ({
@@ -70,9 +80,7 @@ export const useWishlist = () => {
   const extendMutation = useMutation({
     mutationFn: ({ id, formData }: { id: string; formData: WishFormData }) =>
       updateWishlistItem(id, formData),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['wishlistItems'] })
-    },
+    onSuccess: patchWishlistItemCache,
   })
 
   const handleExtend = (id: string, timeOption: (typeof TIME_OPTIONS)[number]) => {
@@ -95,9 +103,7 @@ export const useWishlist = () => {
   const editMutation = useMutation({
     mutationFn: ({ id, formData }: { id: string; formData: WishFormData }) =>
       updateWishlistItem(id, formData),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['wishlistItems'] })
-    },
+    onSuccess: patchWishlistItemCache,
   })
 
   const handleEdit = (id: string, formData: WishFormData) => {

--- a/src/features/temptation/hooks/useWishlistDetail.ts
+++ b/src/features/temptation/hooks/useWishlistDetail.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchWishlistItem } from '../api/wishlistApi'
 import { isUnauthorizedError } from '../utils/isUnauthorizedError'
+import { getMutationErrorKind } from '../utils/wishlistErrors'
 
 export const useWishlistDetail = (id: string | undefined) => {
   const {
@@ -12,14 +13,17 @@ export const useWishlistDetail = (id: string | undefined) => {
     queryKey: ['wishlistItem', id],
     queryFn: () => fetchWishlistItem(id as string),
     enabled: !!id,
+    retry: false,
   })
 
   const isUnauthorized = isUnauthorizedError(error)
+  const errorKind = getMutationErrorKind(error)
 
   return {
     product,
     isLoading,
     isError,
     isUnauthorized,
+    errorKind,
   }
 }

--- a/src/features/temptation/hooks/useWishlistDetail.ts
+++ b/src/features/temptation/hooks/useWishlistDetail.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchWishlistItem } from '../api/wishlistApi'
+import { isUnauthorizedError } from '../utils/isUnauthorizedError'
+
+export const useWishlistDetail = (id: string | undefined) => {
+  const {
+    data: product,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['wishlistItem', id],
+    queryFn: () => fetchWishlistItem(id as string),
+    enabled: !!id,
+  })
+
+  const isUnauthorized = isUnauthorizedError(error)
+
+  return {
+    product,
+    isLoading,
+    isError,
+    isUnauthorized,
+  }
+}

--- a/src/features/temptation/pages/TemptationEdit.tsx
+++ b/src/features/temptation/pages/TemptationEdit.tsx
@@ -12,8 +12,31 @@ import { ConfirmDialog } from '@/shared/components/ConfirmDialog'
 export default function TemptationEdit() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { filteredProducts, handleEdit, isEditing, isEditSuccess, isEditError, resetEditStatus } =
-    useWishlistContext()
+  const {
+    filteredProducts,
+    handleEdit,
+    isEditing,
+    isEditSuccess,
+    isEditError,
+    editErrorKind,
+    resetEditStatus,
+  } = useWishlistContext()
+
+  const errorMessageMap: Record<string, { title: string; description: string }> = {
+    EMPTY: { title: '수정할 내용이 없습니다.', description: '변경된 항목이 있는지 확인해주세요.' },
+    FORBIDDEN: {
+      title: '접근 권한이 없습니다.',
+      description: '본인의 위시리스트 항목만 수정할 수 있습니다.',
+    },
+    NOT_FOUND: {
+      title: '상품을 찾을 수 없습니다.',
+      description: '삭제되었거나 존재하지 않는 상품입니다.',
+    },
+  }
+
+  const editErrorContent = editErrorKind
+    ? errorMessageMap[editErrorKind]
+    : { title: '수정사항을 저장하지 못했습니다.', description: '다시 시도해주세요.' }
 
   const product = filteredProducts.find((p) => p.id === id)
   const [isDirty, setIsDirty] = useState(false)
@@ -123,8 +146,8 @@ export default function TemptationEdit() {
 
       <ConfirmDialog
         isOpen={isEditError}
-        title="수정사항을 저장하지 못했습니다."
-        description="다시 시도해주세요."
+        title={editErrorContent.title}
+        description={editErrorContent.description}
         onlyConfirm
         confirmText="확인"
         onCancel={handleFailConfirm}

--- a/src/features/temptation/pages/TemptationEdit.tsx
+++ b/src/features/temptation/pages/TemptationEdit.tsx
@@ -12,14 +12,11 @@ import { ConfirmDialog } from '@/shared/components/ConfirmDialog'
 export default function TemptationEdit() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { filteredProducts, handleEdit } = useWishlistContext()
+  const { filteredProducts, handleEdit, isEditing, isEditSuccess, isEditError, resetEditStatus } =
+    useWishlistContext()
 
   const product = filteredProducts.find((p) => p.id === id)
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const [isDirty, setIsDirty] = useState(false)
-
-  const [isSuccessOpen, setIsSuccessOpen] = useState(false)
-  const [isFailOpen, setIsFailOpen] = useState(false)
 
   const blocker = useBlocker(
     ({ currentLocation, nextLocation }) =>
@@ -51,29 +48,19 @@ export default function TemptationEdit() {
     blocker.proceed?.()
   }
 
-  const handleSave = async (data: WishFormData, meta: { timeChanged: boolean }) => {
-    if (!product || isSubmitting) return
-    setIsSubmitting(true)
-    try {
-      // 백엔드 연동 시 실제 수정 요청으로 교체
-      await new Promise((resolve) => setTimeout(resolve, 400))
-      handleEdit(product.id, data, meta.timeChanged)
-      setIsSubmitting(false)
-      setIsDirty(false) // 저장 성공 후에는 dirty 해제 (상세 페이지 이동 시 재차단 방지)
-      setIsSuccessOpen(true)
-    } catch {
-      setIsSubmitting(false)
-      setIsFailOpen(true)
-    }
+  const handleSave = (data: WishFormData) => {
+    if (!product || isEditing) return
+    handleEdit(product.id, data)
   }
 
   const handleSuccessConfirm = () => {
-    setIsSuccessOpen(false)
+    setIsDirty(false)
+    resetEditStatus()
     navigate(`/temptation/${id}`)
   }
 
   const handleFailConfirm = () => {
-    setIsFailOpen(false)
+    resetEditStatus()
   }
 
   if (!product) {
@@ -108,9 +95,9 @@ export default function TemptationEdit() {
           type="submit"
           form="edit-wishlist-form"
           className={styles.saveBtn}
-          disabled={isSubmitting}
+          disabled={isEditing}
         >
-          {isSubmitting ? '•  •  •' : '수정사항 저장하기'}
+          {isEditing ? '•  •  •' : '수정사항 저장하기'}
         </button>
       </div>
 
@@ -125,7 +112,7 @@ export default function TemptationEdit() {
       />
 
       <ConfirmDialog
-        isOpen={isSuccessOpen}
+        isOpen={isEditSuccess}
         title="수정사항이 저장되었습니다."
         onlyConfirm
         variant="success"
@@ -135,7 +122,7 @@ export default function TemptationEdit() {
       />
 
       <ConfirmDialog
-        isOpen={isFailOpen}
+        isOpen={isEditError}
         title="수정사항을 저장하지 못했습니다."
         description="다시 시도해주세요."
         onlyConfirm

--- a/src/features/temptation/pages/TemptationInfo.tsx
+++ b/src/features/temptation/pages/TemptationInfo.tsx
@@ -22,7 +22,7 @@ export default function TemptationInfo() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
 
-  const { errorKind } = useWishlistDetail(id)
+  const { isUnauthorized, errorKind } = useWishlistDetail(id)
 
   // 고민 시간이 끝나면 재판단 화면으로 넘깁니다.
   // 이미 지난 채로 들어온 경우엔 즉시, 아직 남았다면 남은 시간만큼 기다린 뒤 이동합니다.
@@ -82,6 +82,48 @@ export default function TemptationInfo() {
     navigate('/temptation')
   }
 
+  if (errorKind === 'NOT_FOUND') {
+    return (
+      <ConfirmDialog
+        isOpen
+        title="상품을 찾을 수 없습니다."
+        description="삭제되었거나 존재하지 않는 상품입니다."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={handleErrorConfirm}
+        onConfirm={handleErrorConfirm}
+      />
+    )
+  }
+
+  if (errorKind === 'FORBIDDEN') {
+    return (
+      <ConfirmDialog
+        isOpen
+        title="접근 권한이 없습니다."
+        description="본인의 위시리스트 항목만 확인할 수 있습니다."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={handleErrorConfirm}
+        onConfirm={handleErrorConfirm}
+      />
+    )
+  }
+
+  if (isUnauthorized) {
+    return (
+      <ConfirmDialog
+        isOpen
+        title="로그인이 필요합니다."
+        description="로그인 후 이용해주세요."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={() => navigate('/login')}
+        onConfirm={() => navigate('/login')}
+      />
+    )
+  }
+
   if (!product) {
     return <p>상품을 찾을 수 없습니다.</p>
   }
@@ -115,26 +157,6 @@ export default function TemptationInfo() {
         errorMessage={errorMessage}
         onCancel={handleGiveUpCancel}
         onConfirm={handleGiveUpConfirm}
-      />
-
-      <ConfirmDialog
-        isOpen={errorKind === 'NOT_FOUND'}
-        title="상품을 찾을 수 없습니다."
-        description="삭제되었거나 존재하지 않는 상품입니다."
-        onlyConfirm
-        confirmText="확인"
-        onCancel={handleErrorConfirm}
-        onConfirm={handleErrorConfirm}
-      />
-
-      <ConfirmDialog
-        isOpen={errorKind === 'FORBIDDEN'}
-        title="접근 권한이 없습니다."
-        description="본인의 위시리스트 항목만 확인할 수 있습니다."
-        onlyConfirm
-        confirmText="확인"
-        onCancel={handleErrorConfirm}
-        onConfirm={handleErrorConfirm}
       />
     </>
   )

--- a/src/features/temptation/pages/TemptationInfo.tsx
+++ b/src/features/temptation/pages/TemptationInfo.tsx
@@ -9,6 +9,7 @@ import styles from './TemptationInfo.module.css'
 import { ConfirmDialog } from '@/shared/components/ConfirmDialog'
 import { useEffect, useState } from 'react'
 import { useWishlistContext } from '../hooks/WishlistContext'
+import { useWishlistDetail } from '../hooks/useWishlistDetail'
 
 export default function TemptationInfo() {
   const { id } = useParams<{ id: string }>()
@@ -20,6 +21,8 @@ export default function TemptationInfo() {
   const [isGiveUpOpen, setIsGiveUpOpen] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
+
+  const { errorKind } = useWishlistDetail(id)
 
   // 고민 시간이 끝나면 재판단 화면으로 넘깁니다.
   // 이미 지난 채로 들어온 경우엔 즉시, 아직 남았다면 남은 시간만큼 기다린 뒤 이동합니다.
@@ -75,6 +78,10 @@ export default function TemptationInfo() {
     }
   }
 
+  const handleErrorConfirm = () => {
+    navigate('/temptation')
+  }
+
   if (!product) {
     return <p>상품을 찾을 수 없습니다.</p>
   }
@@ -86,15 +93,17 @@ export default function TemptationInfo() {
         subLeft={<HeaderBackButton onClick={handleBack} />}
         subMain={<InfoHeader category={product.category} name={product.name} />}
       />
-      <div className={styles.wrapper}>
-        <RemainingTime deadline={product.time} createdAt={product.createdAt} />
-        <InfoBox
-          price={product.price}
-          reason={product.reason ?? undefined}
-          link={product.link ?? undefined}
-        />
-        <ActionButton onEdit={handleEdit} onGiveUp={handleGiveUpOpen} />
-      </div>
+      {product && (
+        <div className={styles.wrapper}>
+          <RemainingTime deadline={product.time} createdAt={product.createdAt} />
+          <InfoBox
+            price={product.price}
+            reason={product.reason ?? undefined}
+            link={product.link ?? undefined}
+          />
+          <ActionButton onEdit={handleEdit} onGiveUp={handleGiveUpOpen} />
+        </div>
+      )}
 
       <ConfirmDialog
         isOpen={isGiveUpOpen}
@@ -106,6 +115,26 @@ export default function TemptationInfo() {
         errorMessage={errorMessage}
         onCancel={handleGiveUpCancel}
         onConfirm={handleGiveUpConfirm}
+      />
+
+      <ConfirmDialog
+        isOpen={errorKind === 'NOT_FOUND'}
+        title="상품을 찾을 수 없습니다."
+        description="삭제되었거나 존재하지 않는 상품입니다."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={handleErrorConfirm}
+        onConfirm={handleErrorConfirm}
+      />
+
+      <ConfirmDialog
+        isOpen={errorKind === 'FORBIDDEN'}
+        title="접근 권한이 없습니다."
+        description="본인의 위시리스트 항목만 확인할 수 있습니다."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={handleErrorConfirm}
+        onConfirm={handleErrorConfirm}
       />
     </>
   )

--- a/src/features/temptation/pages/TemptationJudge.tsx
+++ b/src/features/temptation/pages/TemptationJudge.tsx
@@ -12,7 +12,14 @@ import styles from './TemptationJudge.module.css'
 export default function TemptationJudge() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { filteredProducts, handleDelete, handleExtend } = useWishlistContext()
+  const {
+    filteredProducts,
+    handleDelete,
+    handleExtend,
+    isExtending,
+    isExtendError,
+    resetExtendStatus,
+  } = useWishlistContext()
 
   const product = filteredProducts.find((p) => p.id === id)
   const [selectedExtend, setSelectedExtend] = useState<(typeof TIME_OPTIONS)[number]>('1일')
@@ -39,14 +46,19 @@ export default function TemptationJudge() {
   }
 
   const handleExtendCancel = () => {
+    if (isExtending) return
     setIsExtendConfirmOpen(false)
   }
 
   const handleExtendConfirm = () => {
     if (!product) return
     handleExtend(product.id, selectedExtend)
-    setIsExtendConfirmOpen(false)
-    navigate(`/temptation/${product.id}`)
+    // setIsExtendConfirmOpen(false)
+    // navigate(`/temptation/${product.id}`)
+  }
+
+  const handleExtendFailConfirm = () => {
+    resetExtendStatus()
   }
 
   const handleNotBuy = () => {
@@ -183,6 +195,16 @@ export default function TemptationJudge() {
         confirmText="연장하기"
         onCancel={handleExtendCancel}
         onConfirm={handleExtendConfirm}
+      />
+
+      <ConfirmDialog
+        isOpen={isExtendError}
+        title="연장에 실패했습니다."
+        description="다시 시도해주세요."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={handleExtendFailConfirm}
+        onConfirm={handleExtendFailConfirm}
       />
     </>
   )

--- a/src/features/temptation/pages/TemptationJudge.tsx
+++ b/src/features/temptation/pages/TemptationJudge.tsx
@@ -17,6 +17,7 @@ export default function TemptationJudge() {
     handleDelete,
     handleExtend,
     isExtending,
+    isExtendSuccess,
     isExtendError,
     resetExtendStatus,
   } = useWishlistContext()
@@ -25,6 +26,8 @@ export default function TemptationJudge() {
   const [selectedExtend, setSelectedExtend] = useState<(typeof TIME_OPTIONS)[number]>('1일')
   const [isProcessing, setIsProcessing] = useState(false)
   const [isExtendConfirmOpen, setIsExtendConfirmOpen] = useState(false)
+
+  const isExtendDialogOpen = isExtendConfirmOpen && !isExtendSuccess
 
   // 아직 고민 시간이 남은 상품은 재판단 대상이 아니므로 상세로 돌려보냅니다.
   // (상세 화면은 반대로 시간이 끝나면 이 화면으로 보냅니다 — 조건이 서로 배타적이라 왕복하지 않습니다.)
@@ -53,9 +56,15 @@ export default function TemptationJudge() {
   const handleExtendConfirm = () => {
     if (!product || isExtending) return
     handleExtend(product.id, selectedExtend)
-    setIsExtendConfirmOpen(false)
-    navigate(`/temptation/${id}`, { replace: true })
   }
+
+  // 연장 성공 시: 확인 다이얼로그를 닫고 상세 화면으로 이동.
+  useEffect(() => {
+    if (isExtendSuccess && id) {
+      resetExtendStatus()
+      navigate(`/temptation/${id}`, { replace: true })
+    }
+  }, [isExtendSuccess, id, navigate, resetExtendStatus])
 
   const handleExtendFailConfirm = () => {
     resetExtendStatus()
@@ -189,7 +198,7 @@ export default function TemptationJudge() {
       </div>
 
       <ConfirmDialog
-        isOpen={isExtendConfirmOpen}
+        isOpen={isExtendDialogOpen}
         isLoading={isExtending}
         title={`고민 시간을 ${selectedExtend} 연장할까요?`}
         cancelText="취소"

--- a/src/features/temptation/pages/TemptationJudge.tsx
+++ b/src/features/temptation/pages/TemptationJudge.tsx
@@ -51,10 +51,10 @@ export default function TemptationJudge() {
   }
 
   const handleExtendConfirm = () => {
-    if (!product) return
+    if (!product || isExtending) return
     handleExtend(product.id, selectedExtend)
-    // setIsExtendConfirmOpen(false)
-    // navigate(`/temptation/${product.id}`)
+    setIsExtendConfirmOpen(false)
+    navigate(`/temptation/${id}`, { replace: true })
   }
 
   const handleExtendFailConfirm = () => {
@@ -190,6 +190,7 @@ export default function TemptationJudge() {
 
       <ConfirmDialog
         isOpen={isExtendConfirmOpen}
+        isLoading={isExtending}
         title={`고민 시간을 ${selectedExtend} 연장할까요?`}
         cancelText="취소"
         confirmText="연장하기"

--- a/src/features/temptation/utils/wishlistErrors.ts
+++ b/src/features/temptation/utils/wishlistErrors.ts
@@ -1,0 +1,22 @@
+import { isAxiosError } from 'axios'
+
+export type WishlistErrorKind = 'EMPTY' | 'FORBIDDEN' | 'NOT_FOUND' | 'UNKNOWN'
+
+const ERROR_CODE_MAP: Record<string, WishlistErrorKind> = {
+  WISH4001: 'EMPTY',
+  WISH4031: 'FORBIDDEN',
+  WISH4041: 'NOT_FOUND',
+}
+
+export const getWishlistErrorKind = (error: unknown): WishlistErrorKind | null => {
+  if (!isAxiosError(error) || !error.response) return null
+  const code = error.response.data?.code
+  return ERROR_CODE_MAP[code] ?? null
+}
+
+export const getMutationErrorKind = (error: unknown): WishlistErrorKind | null => {
+  if (error instanceof Error && ['EMPTY', 'FORBIDDEN', 'NOT_FOUND'].includes(error.message)) {
+    return error.message as WishlistErrorKind
+  }
+  return null
+}


### PR DESCRIPTION
## 📌 작업 내용

- `features/temptation/api/wishlistApi.ts` 파일 수정
- `TemptationInfo.tsx` 연동
- 기존 `handleEdit`을 서버 PATCH로 전환
- 에러 처리

  ## 📷 스크린 샷

-

## ⚠️ 참고 사항

- 일부 에러(400, 403, 404) ConfirmDialog 컴포넌트 연결 및 추가가 필요합니다. (어느 페이지에 넣을지 고민하다 우선 PR부터 생성했습니다...)

## 🔗 관련 이슈

Closes #125 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 위시리스트 항목을 개별 조회하고 수정하거나 연장할 수 있습니다.
  * 수정 및 연장 작업의 진행·성공·실패 상태를 확인할 수 있습니다.
  * 수정된 위시리스트 정보를 자동으로 새로고침합니다.

* **버그 수정**
  * 저장 또는 연장 중 중복 제출과 잘못된 화면 이동을 방지합니다.
  * 권한 없음, 존재하지 않는 항목, 빈 결과 등의 오류를 상황에 맞게 안내합니다.
  * 수정 및 연장 실패 시 오류 안내와 재시도 처리를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->