### PR TITLE
✨ [Feature] 토큰 재발급 및 아이디 중복확인 API 연동

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -86,6 +86,27 @@ export const checkEmail = async (email: string): Promise<CheckEmailResponse> => 
   return data
 }
 
+//아이디 중복확인
+
+export interface CheckLoginIdResponse {
+  success: boolean
+  message: string
+
+  data: {
+    available: boolean
+  }
+}
+
+export const checkLoginId = async (loginId: string): Promise<CheckLoginIdResponse> => {
+  const { data } = await client.get<CheckLoginIdResponse>('/api/v1/auth/check-login-id', {
+    params: {
+      loginId,
+    },
+  })
+
+  return data
+}
+
 export const sendVerificationEmail = async (body: SendEmailRequest): Promise<SendEmailResponse> => {
   const { data } = await client.post<SendEmailResponse>('/api/v1/auth/email-verifications', body)
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,12 @@
-import axios from 'axios'
-import { getAccessToken } from '@/shared/auth/session'
+import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios'
+import {
+  getAccessToken,
+  getRefreshToken,
+  saveAuthSession,
+  clearAuthSession,
+} from '@/shared/auth/session'
+
+const REFRESH_URL = '/api/v1/auth/refresh'
 
 const client = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -15,11 +22,54 @@ client.interceptors.request.use((config) => {
   return config
 })
 
+interface RetriableRequestConfig extends InternalAxiosRequestConfig {
+  _retry?: boolean
+}
+
+// 401을 받은 요청들이 동시에 재발급을 여러 번 트리거하지 않도록 하나의 진행 중인 요청을 공유합니다.
+let refreshPromise: Promise<void> | null = null
+
+const refreshAccessToken = async (): Promise<void> => {
+  const refreshToken = getRefreshToken()
+  if (!refreshToken) throw new Error('저장된 refresh token이 없습니다.')
+
+  const { data } = await client.post<{ data: { accessToken: string; refreshToken: string } }>(
+    REFRESH_URL,
+    { refreshToken },
+  )
+  saveAuthSession(data.data)
+}
+
 client.interceptors.response.use(
   (response) => response,
-  (error) => {
-    // 401 처리 등 공통 에러 핸들링
-    return Promise.reject(error)
+  async (error: AxiosError) => {
+    const originalRequest = error.config as RetriableRequestConfig | undefined
+
+    const shouldTryRefresh =
+      error.response?.status === 401 &&
+      originalRequest !== undefined &&
+      originalRequest.url !== REFRESH_URL &&
+      !originalRequest._retry &&
+      getRefreshToken() !== null
+
+    if (!shouldTryRefresh) {
+      return Promise.reject(error)
+    }
+
+    originalRequest._retry = true
+
+    try {
+      refreshPromise ??= refreshAccessToken().finally(() => {
+        refreshPromise = null
+      })
+      await refreshPromise
+      return client(originalRequest)
+    } catch {
+      // refresh token도 만료/무효인 경우: 세션을 정리하고 원래 401을 그대로 전달해
+      // 각 화면의 기존 isUnauthorizedError 처리(로그인 화면 이동)가 동작하도록 합니다.
+      clearAuthSession()
+      return Promise.reject(error)
+    }
   },
 )
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,4 +1,4 @@
-import axios, { type AxiosError, type InternalAxiosRequestConfig } from 'axios'
+import axios, { isAxiosError, type AxiosError, type InternalAxiosRequestConfig } from 'axios'
 import {
   getAccessToken,
   getRefreshToken,
@@ -64,10 +64,13 @@ client.interceptors.response.use(
       })
       await refreshPromise
       return client(originalRequest)
-    } catch {
-      // refresh token도 만료/무효인 경우: 세션을 정리하고 원래 401을 그대로 전달해
-      // 각 화면의 기존 isUnauthorizedError 처리(로그인 화면 이동)가 동작하도록 합니다.
-      clearAuthSession()
+    } catch (refreshError) {
+      // refresh token 자체가 만료/무효하다고 서버가 401로 확인해준 경우에만 세션을 정리합니다.
+      // 네트워크 오류·타임아웃·5xx 같은 일시적 실패까지 세션을 지우면, refresh token은
+      // 아직 유효한데 재발급 시도가 잠깐 실패했다는 이유로 사용자가 강제 로그아웃됩니다.
+      if (isAxiosError(refreshError) && refreshError.response?.status === 401) {
+        clearAuthSession()
+      }
       return Promise.reject(error)
     }
   },

--- a/src/features/auth/components/SignUpForm.tsx
+++ b/src/features/auth/components/SignUpForm.tsx
@@ -8,6 +8,7 @@ import { useSignup } from '@/hooks/useSignup'
 import { useSendVerificationEmail } from '@/hooks/useSendVerificationEmail'
 import { useConfirmVerificationEmail } from '@/hooks/useConfirmVerificationEmail'
 import { useCheckEmail } from '@/hooks/useCheckEmail'
+import { useCheckLoginId } from '@/hooks/useCheckLoginId'
 import { isAxiosError } from 'axios'
 
 // 서버 오류 응답에서 사용자에게 보여줄 문구를 뽑아냅니다.
@@ -53,9 +54,13 @@ export default function SignUpForm() {
   const { mutate: sendEmail, isPending: isSendingEmail } = useSendVerificationEmail()
   const { mutate: confirmEmail, isPending: isConfirmingEmail } = useConfirmVerificationEmail()
   const { mutate: checkEmail, isPending: isCheckingEmail } = useCheckEmail()
+  const { mutate: checkLoginId, isPending: isCheckingId } = useCheckLoginId()
 
   const [name, setName] = useState('')
   const [id, setId] = useState('')
+  const [isIdAvailable, setIsIdAvailable] = useState(false)
+  // 진행 중인 요청의 응답이 현재 입력값 기준으로 유효한지 판단하기 위한 최신 아이디
+  const latestIdRef = useRef(id)
 
   const [email, setEmail] = useState('')
   const [code, setCode] = useState('')
@@ -66,6 +71,7 @@ export default function SignUpForm() {
 
   // 서버 응답 안내를 입력칸 아래에 표시하기 위한 상태
   type FieldStatus = { type: 'success' | 'error'; message: string } | null
+  const [idStatus, setIdStatus] = useState<FieldStatus>(null)
   const [emailStatus, setEmailStatus] = useState<FieldStatus>(null)
   const [codeStatus, setCodeStatus] = useState<FieldStatus>(null)
   const [submitError, setSubmitError] = useState('')
@@ -84,6 +90,7 @@ export default function SignUpForm() {
   const canSubmit =
     name.trim() !== '' &&
     isValidId &&
+    isIdAvailable &&
     isValidEmail &&
     isValidPassword &&
     isPasswordMatch &&
@@ -114,6 +121,36 @@ export default function SignUpForm() {
         },
       },
     )
+  }
+
+  const handleCheckId = () => {
+    if (!isValidId || isCheckingId) return
+
+    const requestedId = id
+    const isStale = () => requestedId !== latestIdRef.current
+    setIdStatus(null)
+
+    checkLoginId(requestedId, {
+      onSuccess: (response) => {
+        if (isStale()) return
+
+        if (!response.data.available) {
+          setIsIdAvailable(false)
+          setIdStatus({ type: 'error', message: '이미 사용 중인 아이디입니다.' })
+          return
+        }
+
+        setIsIdAvailable(true)
+        setIdStatus({ type: 'success', message: '사용 가능한 아이디입니다.' })
+      },
+      onError: (error) => {
+        if (isStale()) return
+        setIdStatus({
+          type: 'error',
+          message: getErrorMessage(error, '아이디 확인에 실패했습니다. 잠시 후 다시 시도해주세요.'),
+        })
+      },
+    })
   }
 
   // 중복 확인을 통과한 이메일에만 인증 메일을 보냅니다.
@@ -212,22 +249,48 @@ export default function SignUpForm() {
         />
       </div>
 
-      <div className={styles.formField}>
-        <InputField
-          label="아이디"
-          placeholder="영문, 숫자 조합 6~12자"
-          value={id}
-          onChange={(e) => setId(e.target.value)}
-        />
-        {id.length > 0 && (
-          <ErrorMessage
-            type={isValidId ? 'success' : 'error'}
-            message={
-              isValidId ? '올바른 아이디 형식입니다.' : '영문, 숫자 조합 6~12자로 입력해주세요.'
-            }
+      <div className={styles.inputWithButton}>
+        <label htmlFor="loginId" className={styles.label}>
+          아이디
+        </label>
+
+        <div className={styles.row}>
+          <input
+            id="loginId"
+            className={styles.input}
+            placeholder="영문, 숫자 조합 6~12자"
+            value={id}
+            onChange={(e) => {
+              const nextId = e.target.value
+              latestIdRef.current = nextId
+              setId(nextId)
+              // 아이디가 바뀌면 이전 아이디로 받은 중복확인 결과는 모두 무효입니다.
+              setIsIdAvailable(false)
+              setIdStatus(null)
+            }}
           />
-        )}
+
+          <button
+            type="button"
+            className={styles.smallButton}
+            disabled={!isValidId || isCheckingId}
+            onClick={handleCheckId}
+          >
+            중복확인
+          </button>
+        </div>
       </div>
+
+      {id.length > 0 && (
+        <ErrorMessage
+          type={isValidId ? 'success' : 'error'}
+          message={
+            isValidId ? '올바른 아이디 형식입니다.' : '영문, 숫자 조합 6~12자로 입력해주세요.'
+          }
+        />
+      )}
+
+      {idStatus && <ErrorMessage type={idStatus.type} message={idStatus.message} />}
 
       <div className={styles.inputWithButton}>
         <label htmlFor="email" className={styles.label}>

--- a/src/hooks/useCheckLoginId.ts
+++ b/src/hooks/useCheckLoginId.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query'
+import { checkLoginId } from '@/api/auth'
+
+export const useCheckLoginId = () => {
+  return useMutation({
+    mutationFn: checkLoginId,
+  })
+}


### PR DESCRIPTION
## 📌 작업 내용

- `POST /api/v1/auth/refresh` 연동: accessToken 만료(401) 시 refreshToken으로 자동 재발급받고 원래 요청을 재시도하도록 axios 인터셉터에 추가 (`src/api/client.ts`)
  - 응답으로 내려오는 로테이션된 refreshToken까지 함께 갱신 저장
  - 동시에 여러 요청이 401을 받아도 재발급 요청은 한 번만 발생하도록 Promise 공유 처리
  - refreshToken까지 만료/무효한 경우 세션 정리 후 원래 401 에러를 그대로 전달해 기존 화면별 `isUnauthorizedError` 처리(로그인 이동)가 그대로 동작하도록 유지
- `GET /api/v1/auth/check-login-id` 연동: 회원가입 폼의 아이디 필드에 이메일과 동일한 패턴(중복확인 버튼 → 통과 전까지 제출 불가 → 값 수정 시 상태 초기화)으로 실시간 중복확인 추가 (`src/api/auth.ts`, `src/hooks/useCheckLoginId.ts`, `src/features/auth/components/SignUpForm.tsx`)


## ⚠️ 참고 사항

- Playwright로 401→재발급→재시도 성공, 토큰 로테이션 저장, 동시 401 시 재발급 1회만 호출, refreshToken 무효 시 세션 정리 및 기존 401 처리 유지, 아이디 중복확인 성공/실패/상태초기화 케이스를 모두 확인했습니다.
- `tsc -b`, `eslint`, `vitest`(51/51), `npm run build` 모두 통과했습니다.

## 🔗 관련 이슈

Closes #139


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 회원가입 시 아이디 중복 확인 기능을 추가했습니다.
  - 아이디가 사용 가능한 경우에만 회원가입을 완료할 수 있습니다.
  - 인증 오류 발생 시 로그인 상태를 자동으로 갱신하고 요청을 재시도합니다.

- **개선**
  - 아이디를 변경하면 이전 중복 확인 결과가 초기화되어 최신 상태로 다시 확인하도록 개선했습니다.
  - 인증 갱신에 실패하면 세션을 정리하고 기존 오류 처리를 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->