### PR TITLE
✨ [Feature] 위시리스트 삭제 API 연동

### DIFF
--- a/src/features/temptation/api/wishlistApi.ts
+++ b/src/features/temptation/api/wishlistApi.ts
@@ -137,3 +137,9 @@ export const updateWishlistItem = async (id: string, formData: WishFormData): Pr
     return mapToProduct(data.data)
   })
 }
+
+export const deleteWishlistItem = async (id: string): Promise<void> => {
+  return wishlistErrorHandling(async () => {
+    await client.delete(`/api/v1/wishlist-items/${id}`)
+  })
+}

--- a/src/features/temptation/hooks/useWishlist.ts
+++ b/src/features/temptation/hooks/useWishlist.ts
@@ -118,7 +118,11 @@ export const useWishlist = () => {
     isUnauthorizedError(error) ||
     isUnauthorizedError(addMutation.error) ||
     isUnauthorizedError(editMutation.error) ||
-    isUnauthorizedError(extendMutation.error)
+    isUnauthorizedError(extendMutation.error) ||
+    isUnauthorizedError(deleteMutation.error)
+
+  // 삭제 401 에러 여부를 별도 노출 (상세 화면/재판단 화면에서 로그인 분기용)
+  const isDeleteUnauthorized = isUnauthorizedError(deleteMutation.error)
 
   const editErrorKind = getMutationErrorKind(editMutation.error) // 'EMPTY' | 'FORBIDDEN' | 'NOT_FOUND' | null
   const deleteErrorKind = getMutationErrorKind(deleteMutation.error)
@@ -147,6 +151,7 @@ export const useWishlist = () => {
     isDeleting: deleteMutation.isPending,
     isDeleteSuccess: deleteMutation.isSuccess,
     isDeleteError: deleteMutation.isError,
+    isDeleteUnauthorized,
     deleteErrorKind,
     resetDeleteStatus: deleteMutation.reset,
     isUnauthorized,

--- a/src/features/temptation/hooks/useWishlist.ts
+++ b/src/features/temptation/hooks/useWishlist.ts
@@ -3,7 +3,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { CATEGORIES, TIME_OPTIONS } from '@/constants/product'
 import type { Category, FilterValue, SortValue, Product } from '../types'
 import type { FormData as WishFormData } from '@/components/layout/ProductForm'
-import { fetchWishlistItems, addWishlistItem, updateWishlistItem } from '../api/wishlistApi'
+import {
+  fetchWishlistItems,
+  addWishlistItem,
+  updateWishlistItem,
+  deleteWishlistItem,
+} from '../api/wishlistApi'
 import { isUnauthorizedError } from '../utils/isUnauthorizedError'
 import { getMutationErrorKind } from '../utils/wishlistErrors'
 
@@ -11,7 +16,7 @@ export const useWishlist = () => {
   const queryClient = useQueryClient()
 
   const {
-    data: serverProducts = [],
+    data: products = [],
     isLoading,
     isError,
     error,
@@ -19,16 +24,6 @@ export const useWishlist = () => {
     queryKey: ['wishlistItems'],
     queryFn: fetchWishlistItems,
   })
-
-  // 연동 전 API에 대한 임시 방편
-  // 연동 후 해당 부분 삭제, serverProducts를 직접 사용하도록 변경
-  const [localOverrides, setLocalOverrides] = useState<{ deletedIds: Set<string> }>({
-    deletedIds: new Set(),
-  })
-
-  const products = useMemo(() => {
-    return serverProducts.filter((p) => !localOverrides.deletedIds.has(p.id))
-  }, [serverProducts, localOverrides])
 
   const [filter, setFilter] = useState<FilterValue>('전체')
   const [sort, setSort] = useState<SortValue>('가나다순')
@@ -66,11 +61,18 @@ export const useWishlist = () => {
     queryClient.invalidateQueries({ queryKey: ['wishlistItems'] })
   }
 
+  const deleteMutation = useMutation({
+    mutationFn: deleteWishlistItem,
+    onSuccess: (_data, deletedId) => {
+      queryClient.setQueryData<Product[]>(['wishlistItems'], (old) =>
+        old?.filter((p) => p.id !== deletedId),
+      )
+      queryClient.invalidateQueries({ queryKey: ['wishlistItems'] })
+    },
+  })
+
   const handleDelete = (id: string) => {
-    console.warn(`API 연동 전! (id: ${id}) 다음 이슈에서 작업 예정`)
-    setLocalOverrides((prev) => ({
-      deletedIds: new Set(prev.deletedIds).add(id),
-    }))
+    deleteMutation.mutate(id)
   }
 
   const handleAdd = (formData: WishFormData) => {
@@ -119,6 +121,7 @@ export const useWishlist = () => {
     isUnauthorizedError(extendMutation.error)
 
   const editErrorKind = getMutationErrorKind(editMutation.error) // 'EMPTY' | 'FORBIDDEN' | 'NOT_FOUND' | null
+  const deleteErrorKind = getMutationErrorKind(deleteMutation.error)
 
   return {
     keyword,
@@ -141,6 +144,11 @@ export const useWishlist = () => {
     isExtendSuccess: extendMutation.isSuccess,
     isExtendError: extendMutation.isError,
     resetExtendStatus: extendMutation.reset,
+    isDeleting: deleteMutation.isPending,
+    isDeleteSuccess: deleteMutation.isSuccess,
+    isDeleteError: deleteMutation.isError,
+    deleteErrorKind,
+    resetDeleteStatus: deleteMutation.reset,
     isUnauthorized,
     handleDelete,
     handleAdd,

--- a/src/features/temptation/pages/TemptationInfo.tsx
+++ b/src/features/temptation/pages/TemptationInfo.tsx
@@ -20,6 +20,7 @@ export default function TemptationInfo() {
     isDeleting,
     isDeleteSuccess,
     isDeleteError,
+    isDeleteUnauthorized,
     deleteErrorKind,
     resetDeleteStatus,
   } = useWishlistContext()
@@ -50,6 +51,14 @@ export default function TemptationInfo() {
     const timer = setTimeout(goJudge, remainMs)
     return () => clearTimeout(timer)
   }, [id, deadlineMs, navigate])
+
+  // 삭제 성공 시 리셋 및 이동 처리
+  useEffect(() => {
+    if (isDeleteSuccess) {
+      resetDeleteStatus()
+      navigate('/temptation')
+    }
+  }, [isDeleteSuccess, resetDeleteStatus, navigate])
 
   const handleBack = () => {
     navigate('/temptation')
@@ -119,13 +128,21 @@ export default function TemptationInfo() {
         description="로그인 후 이용해주세요."
         onlyConfirm
         confirmText="확인"
-        onCancel={() => navigate('/login')}
-        onConfirm={() => navigate('/login')}
+        onCancel={() => {
+          resetDeleteStatus()
+          navigate('/login')
+        }}
+        onConfirm={() => {
+          resetDeleteStatus()
+          navigate('/login')
+        }}
       />
     )
   }
 
   if (!product) {
+    // 이동하는 동안 잠시 동안 빈 화면을 렌더링하도록 함
+    if (isDeleteSuccess) return null
     return <p>상품을 찾을 수 없습니다.</p>
   }
 
@@ -161,7 +178,7 @@ export default function TemptationInfo() {
       />
 
       <ConfirmDialog
-        isOpen={isDeleteError && deleteErrorKind === null}
+        isOpen={isDeleteError && deleteErrorKind === null && !isDeleteUnauthorized}
         title="처리하지 못했습니다."
         description="잠시 후 다시 시도해주세요."
         onlyConfirm

--- a/src/features/temptation/pages/TemptationInfo.tsx
+++ b/src/features/temptation/pages/TemptationInfo.tsx
@@ -14,12 +14,21 @@ import { useWishlistDetail } from '../hooks/useWishlistDetail'
 export default function TemptationInfo() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const { filteredProducts, handleDelete } = useWishlistContext()
+  const {
+    filteredProducts,
+    handleDelete,
+    isDeleting,
+    isDeleteSuccess,
+    isDeleteError,
+    deleteErrorKind,
+    resetDeleteStatus,
+  } = useWishlistContext()
 
   const product = filteredProducts.find((p) => p.id === id)
 
   const [isGiveUpOpen, setIsGiveUpOpen] = useState(false)
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const isGiveUpDialogOpen = isGiveUpOpen && !isDeleteSuccess
+
   const [errorMessage, setErrorMessage] = useState('')
 
   const { isUnauthorized, errorKind } = useWishlistDetail(id)
@@ -56,26 +65,18 @@ export default function TemptationInfo() {
   }
 
   const handleGiveUpCancel = () => {
-    if (isSubmitting) return
+    if (isDeleting) return
     setIsGiveUpOpen(false)
     setErrorMessage('')
   }
 
   const handleGiveUpConfirm = async () => {
     if (!product) return
-    setIsSubmitting(true)
-    setErrorMessage('')
+    handleDelete(product.id)
+  }
 
-    try {
-      // 백엔드 연동 시 실제 삭제 요청으로 교체 필요
-      await new Promise((resolve) => setTimeout(resolve, 400))
-      handleDelete(product.id)
-      navigate('/temptation')
-    } catch {
-      setErrorMessage('처리하지 못했습니다. 다시 시도해 주세요.')
-    } finally {
-      setIsSubmitting(false)
-    }
+  const handleDeleteFailConfirm = () => {
+    resetDeleteStatus()
   }
 
   const handleErrorConfirm = () => {
@@ -148,15 +149,48 @@ export default function TemptationInfo() {
       )}
 
       <ConfirmDialog
-        isOpen={isGiveUpOpen}
+        isOpen={isGiveUpDialogOpen}
         title="이 상품을 포기하시겠습니까?"
         description="포기한 금액은 참은 소비 기록에 반영됩니다."
         cancelText="취소"
         confirmText="포기하기"
-        isLoading={isSubmitting}
+        isLoading={isDeleting}
         errorMessage={errorMessage}
         onCancel={handleGiveUpCancel}
         onConfirm={handleGiveUpConfirm}
+      />
+
+      <ConfirmDialog
+        isOpen={isDeleteError && deleteErrorKind === null}
+        title="처리하지 못했습니다."
+        description="잠시 후 다시 시도해주세요."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={handleDeleteFailConfirm}
+        onConfirm={handleDeleteFailConfirm}
+      />
+
+      <ConfirmDialog
+        isOpen={deleteErrorKind === 'NOT_FOUND'}
+        title="상품을 찾을 수 없습니다."
+        description="이미 삭제되었거나 존재하지 않는 상품입니다."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={handleDeleteFailConfirm}
+        onConfirm={() => {
+          resetDeleteStatus()
+          navigate('/temptation')
+        }}
+      />
+
+      <ConfirmDialog
+        isOpen={deleteErrorKind === 'FORBIDDEN'}
+        title="접근 권한이 없습니다."
+        description="본인의 위시리스트 항목만 삭제할 수 있습니다."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={handleDeleteFailConfirm}
+        onConfirm={handleDeleteFailConfirm}
       />
     </>
   )

--- a/src/features/temptation/pages/TemptationJudge.tsx
+++ b/src/features/temptation/pages/TemptationJudge.tsx
@@ -15,6 +15,10 @@ export default function TemptationJudge() {
   const {
     filteredProducts,
     handleDelete,
+    isDeleting,
+    isDeleteSuccess,
+    isDeleteError,
+    resetDeleteStatus,
     handleExtend,
     isExtending,
     isExtendSuccess,
@@ -24,7 +28,6 @@ export default function TemptationJudge() {
 
   const product = filteredProducts.find((p) => p.id === id)
   const [selectedExtend, setSelectedExtend] = useState<(typeof TIME_OPTIONS)[number]>('1일')
-  const [isProcessing, setIsProcessing] = useState(false)
   const [isExtendConfirmOpen, setIsExtendConfirmOpen] = useState(false)
 
   const isExtendDialogOpen = isExtendConfirmOpen && !isExtendSuccess
@@ -44,7 +47,7 @@ export default function TemptationJudge() {
   }
 
   const handleExtendClick = () => {
-    if (!product || isProcessing) return
+    if (!product || isExtending) return
     setIsExtendConfirmOpen(true)
   }
 
@@ -70,15 +73,17 @@ export default function TemptationJudge() {
     resetExtendStatus()
   }
 
+  // TODO: 참은 소비 기록 저장 API 연동 필요.
+  // 연동 시에는 저장에 성공한 뒤 handleDelete를 호출하고,
+  // 실패하면 삭제하지 않은 채 setIsProcessing(false)로 되돌리고 오류를 표시해야 합니다.
   const handleNotBuy = () => {
-    if (!product || isProcessing) return
-    setIsProcessing(true)
+    if (!product || isDeleting) return
+    handleDelete(product.id)
+  }
 
-    // TODO: 참은 소비 기록 저장 API 연동 필요.
-    // 연동 시에는 저장에 성공한 뒤 handleDelete를 호출하고,
-    // 실패하면 삭제하지 않은 채 setIsProcessing(false)로 되돌리고 오류를 표시해야 합니다.
-    try {
-      handleDelete(product.id)
+  useEffect(() => {
+    if (isDeleteSuccess && product) {
+      resetDeleteStatus()
       navigate('/temptation/saved', {
         state: {
           name: product.name,
@@ -86,13 +91,15 @@ export default function TemptationJudge() {
           price: product.price,
         },
       })
-    } catch {
-      setIsProcessing(false)
     }
+  }, [isDeleteSuccess, product, resetDeleteStatus, navigate])
+
+  const handleDeleteFailConfirm = () => {
+    resetDeleteStatus()
   }
 
   const handleBuy = () => {
-    if (!product || isProcessing) return
+    if (!product || isDeleting) return
     navigate('/record/intervention', {
       state: {
         from: 'temptation',
@@ -158,7 +165,7 @@ export default function TemptationJudge() {
             type="button"
             className={styles.extendConfirmBtn}
             onClick={handleExtendClick}
-            disabled={isProcessing}
+            disabled={isDeleting}
           >
             {selectedExtend} 연장 확정하기
           </button>
@@ -179,7 +186,7 @@ export default function TemptationJudge() {
               type="button"
               className={styles.notBuyBtn}
               onClick={handleNotBuy}
-              disabled={isProcessing}
+              disabled={isDeleting}
             >
               <span className={styles.decisionMain}>안 살래요</span>
               <span className={styles.decisionSub}>참을게요</span>
@@ -188,7 +195,7 @@ export default function TemptationJudge() {
               type="button"
               className={styles.buyBtn}
               onClick={handleBuy}
-              disabled={isProcessing}
+              disabled={isDeleting}
             >
               <span className={styles.decisionMain}>살래요</span>
               <span className={styles.decisionSub}>점검 후 구매</span>
@@ -215,6 +222,16 @@ export default function TemptationJudge() {
         confirmText="확인"
         onCancel={handleExtendFailConfirm}
         onConfirm={handleExtendFailConfirm}
+      />
+
+      <ConfirmDialog
+        isOpen={isDeleteError}
+        title="처리하지 못했습니다."
+        description="잠시 후 다시 시도해주세요."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={handleDeleteFailConfirm}
+        onConfirm={handleDeleteFailConfirm}
       />
     </>
   )

--- a/src/features/temptation/pages/TemptationJudge.tsx
+++ b/src/features/temptation/pages/TemptationJudge.tsx
@@ -8,6 +8,7 @@ import { useWishlistContext } from '../hooks/WishlistContext'
 import { ProductSummaryCard } from '../components/temptationJudge/ProductSummaryCard'
 import { TIME_OPTIONS } from '@/constants/product'
 import styles from './TemptationJudge.module.css'
+import type { Product } from '../types'
 
 export default function TemptationJudge() {
   const { id } = useParams<{ id: string }>()
@@ -18,6 +19,7 @@ export default function TemptationJudge() {
     isDeleting,
     isDeleteSuccess,
     isDeleteError,
+    isDeleteUnauthorized,
     resetDeleteStatus,
     handleExtend,
     isExtending,
@@ -29,6 +31,12 @@ export default function TemptationJudge() {
   const product = filteredProducts.find((p) => p.id === id)
   const [selectedExtend, setSelectedExtend] = useState<(typeof TIME_OPTIONS)[number]>('1일')
   const [isExtendConfirmOpen, setIsExtendConfirmOpen] = useState(false)
+  // 삭제 요청 이전에 삭제할 상품 정보(name, category, price)를 보존(저장),
+  // 삭제 성공 시 이동할 화면에 전달
+  const [deletedProductInfo, setDeletedProductInfo] = useState<Pick<
+    Product,
+    'name' | 'category' | 'price'
+  > | null>(null)
 
   const isExtendDialogOpen = isExtendConfirmOpen && !isExtendSuccess
 
@@ -78,21 +86,20 @@ export default function TemptationJudge() {
   // 실패하면 삭제하지 않은 채 setIsProcessing(false)로 되돌리고 오류를 표시해야 합니다.
   const handleNotBuy = () => {
     if (!product || isDeleting) return
+    setDeletedProductInfo({
+      name: product.name,
+      category: product.category,
+      price: product.price,
+    })
     handleDelete(product.id)
   }
 
   useEffect(() => {
-    if (isDeleteSuccess && product) {
+    if (isDeleteSuccess && deletedProductInfo) {
       resetDeleteStatus()
-      navigate('/temptation/saved', {
-        state: {
-          name: product.name,
-          category: product.category,
-          price: product.price,
-        },
-      })
+      navigate('/temptation/saved', { state: deletedProductInfo })
     }
-  }, [isDeleteSuccess, product, resetDeleteStatus, navigate])
+  }, [isDeleteSuccess, deletedProductInfo, resetDeleteStatus, navigate])
 
   const handleDeleteFailConfirm = () => {
     resetDeleteStatus()
@@ -225,13 +232,29 @@ export default function TemptationJudge() {
       />
 
       <ConfirmDialog
-        isOpen={isDeleteError}
+        isOpen={isDeleteError && !isDeleteUnauthorized}
         title="처리하지 못했습니다."
         description="잠시 후 다시 시도해주세요."
         onlyConfirm
         confirmText="확인"
         onCancel={handleDeleteFailConfirm}
         onConfirm={handleDeleteFailConfirm}
+      />
+
+      <ConfirmDialog
+        isOpen={isDeleteUnauthorized}
+        title="로그인이 필요합니다."
+        description="로그인 후 이용해주세요."
+        onlyConfirm
+        confirmText="확인"
+        onCancel={() => {
+          resetDeleteStatus()
+          navigate('/login')
+        }}
+        onConfirm={() => {
+          resetDeleteStatus()
+          navigate('/login')
+        }}
       />
     </>
   )

--- a/src/features/temptation/pages/TemptationJudge.tsx
+++ b/src/features/temptation/pages/TemptationJudge.tsx
@@ -85,7 +85,7 @@ export default function TemptationJudge() {
   // 연동 시에는 저장에 성공한 뒤 handleDelete를 호출하고,
   // 실패하면 삭제하지 않은 채 setIsProcessing(false)로 되돌리고 오류를 표시해야 합니다.
   const handleNotBuy = () => {
-    if (!product || isDeleting) return
+    if (!product || isDeleting || isExtending) return
     setDeletedProductInfo({
       name: product.name,
       category: product.category,
@@ -106,7 +106,7 @@ export default function TemptationJudge() {
   }
 
   const handleBuy = () => {
-    if (!product || isDeleting) return
+    if (!product || isDeleting || isExtending) return
     navigate('/record/intervention', {
       state: {
         from: 'temptation',
@@ -193,7 +193,7 @@ export default function TemptationJudge() {
               type="button"
               className={styles.notBuyBtn}
               onClick={handleNotBuy}
-              disabled={isDeleting}
+              disabled={isDeleting || isExtending}
             >
               <span className={styles.decisionMain}>안 살래요</span>
               <span className={styles.decisionSub}>참을게요</span>
@@ -202,7 +202,7 @@ export default function TemptationJudge() {
               type="button"
               className={styles.buyBtn}
               onClick={handleBuy}
-              disabled={isDeleting}
+              disabled={isDeleting || isExtending}
             >
               <span className={styles.decisionMain}>살래요</span>
               <span className={styles.decisionSub}>점검 후 구매</span>


### PR DESCRIPTION
## 📌 작업 내용

- `wishlistApi.ts` 파일 수정
- `useWishlist.ts` 파일 수정
- `TemptationInfo.tsx`: "포기하기" 확인 다이얼로그의 삭제 로직
- `TemptationJudge.tsx`: "안 살래요" 선택 시 삭제 로직
- 에러 처리

## 📷 스크린 샷

-

## ⚠️ 참고 사항

- (화면 UI의 경우) 메인 화면의 삭제(✕) 버튼에는 추가로 수정해야 하는 부분이 없어 상세 화면, 재판단 화면만 수정되었습니다.

## 🔗 관련 이슈

Closes #126 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 저장한 항목을 서버에서 삭제할 수 있습니다.
  - 삭제 진행 상태와 성공·실패 결과가 화면에 반영됩니다.
  - 삭제 실패 유형에 따라 안내 대화상자가 표시됩니다.
  - 인증 오류 발생 시 로그인 화면으로 이동합니다.

- **버그 수정**
  - 삭제 성공 후 목록이 즉시 갱신됩니다.
  - 삭제 중 중복 작업을 방지합니다.
  - 삭제 성공 시 관련 상품 정보와 함께 저장 목록으로 올바르게 이동합니다.
  - 이미 삭제된 항목이나 권한 오류 발생 시 적절한 안내와 이동을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->